### PR TITLE
Add critique review step to workflow

### DIFF
--- a/benchmark.py
+++ b/benchmark.py
@@ -65,7 +65,8 @@ def run_benchmark(test_filepath: str, is_trained: bool):
                 if "__end__" in event:
                     final_event = event["__end__"]
 
-            critique_scores = final_event.get('critique_scores', [])
+            final_state = final_event or {}
+            critique_scores = final_state.get('critique_scores', [])
             
             row_data = {'case_id': case_id}
             for item in critique_scores:

--- a/src/graph.py
+++ b/src/graph.py
@@ -6,6 +6,7 @@ from src.nodes import (
     associate_judge_deliberation_node,
     final_judgment_node,
     update_knowledge_base_node,
+    critique_node,
 )
 
 # 조건부 엣지를 위한 함수
@@ -21,6 +22,7 @@ workflow.add_node("lawyer_debate", lawyer_debate_node)
 workflow.add_node("associate_judge_deliberation", associate_judge_deliberation_node)
 workflow.add_node("final_judgment", final_judgment_node)
 workflow.add_node("update_knowledge_base", update_knowledge_base_node)
+workflow.add_node("critique", critique_node)
 
 # 엣지(흐름) 연결
 workflow.set_entry_point("start_trial")
@@ -32,7 +34,8 @@ workflow.add_conditional_edges(
 )
 workflow.add_edge("associate_judge_deliberation", "final_judgment")
 workflow.add_edge("final_judgment", "update_knowledge_base")
-workflow.add_edge("update_knowledge_base", END)
+workflow.add_edge("update_knowledge_base", "critique")
+workflow.add_edge("critique", END)
 
 # 그래프 컴파일
 app = workflow.compile()


### PR DESCRIPTION
## Summary
- register the critique node in the trial workflow and route the update step through it before ending
- make the benchmark runner robust to missing final events so critique scores are always read safely

## Testing
- python -m compileall src

------
https://chatgpt.com/codex/tasks/task_e_68cdabd299d88324af113b8c3c2878ad