### PR TITLE
Add database initialization script for pgvector

### DIFF
--- a/init.sql
+++ b/init.sql
@@ -1,0 +1,30 @@
+-- PostgreSQL initialization script for the vector database
+-- Ensures the pgvector extension and LangChain tables exist on startup.
+
+-- Enable pgvector to store embedding vectors.
+CREATE EXTENSION IF NOT EXISTS vector;
+
+-- Collection table used by langchain_postgres to group embeddings.
+CREATE TABLE IF NOT EXISTS langchain_pg_collection (
+    uuid UUID PRIMARY KEY,
+    name VARCHAR NOT NULL UNIQUE,
+    cmetadata JSON
+);
+
+-- Embedding storage table matching langchain_postgres expectations.
+CREATE TABLE IF NOT EXISTS langchain_pg_embedding (
+    id VARCHAR PRIMARY KEY,
+    collection_id UUID REFERENCES langchain_pg_collection (uuid) ON DELETE CASCADE,
+    embedding VECTOR,
+    document VARCHAR,
+    cmetadata JSONB
+);
+
+-- Index metadata for efficient filtering by JSON properties.
+CREATE INDEX IF NOT EXISTS ix_cmetadata_gin
+    ON langchain_pg_embedding USING GIN (cmetadata jsonb_path_ops);
+
+-- Optional helper index to speed up joins on collection references.
+CREATE INDEX IF NOT EXISTS ix_langchain_pg_embedding_collection_id
+    ON langchain_pg_embedding (collection_id);
+


### PR DESCRIPTION
## Summary
- add an init.sql file mounted by docker-compose to bootstrap the Postgres container
- create the pgvector extension and ensure the LangChain tables and indexes exist on startup

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68cdb10aa4108324a2439d5b97349bca