### PR TITLE
Refactor pipeline for legal assistant architecture

### DIFF
--- a/batch_learn.py
+++ b/batch_learn.py
@@ -1,96 +1,118 @@
+"""Utility script to bulk ingest public precedent data into PostgreSQL."""
+from __future__ import annotations
+
 import json
-import time
-import os
-from src.agents import (
-    redis_client,
-    batch_judge_chain,
-    evaluation_chain,
-    reflection_chain
-)
-from src.vector_db import add_case_to_db
-import src.console as console
-from rich.rule import Rule
+import sys
+from contextlib import closing
+from datetime import datetime
+from pathlib import Path
+from typing import Iterable, List
 
-def run_batch_learning(filepath: str):
-    """
-    .jsonl 파일로부터 여러 사건 데이터를 읽어와 일괄 학습을 수행합니다.
-    """
-    console.print_header("데이터셋 일괄 학습 시작")
+from rich import print
+from rich.progress import track
 
-    try:
-        with open(filepath, 'r', encoding='utf-8') as f:
-            cases = [json.loads(line) for line in f]
-    except FileNotFoundError:
-        console.console.print(f"[bold red]오류: 파일을 찾을 수 없습니다 - {filepath}[/bold red]")
+from src.db_utils import get_db_connection
+from src.file_processor import EMBEDDING_DIM, EMBEDDING_MODEL
+from langchain_community.embeddings import SentenceTransformerEmbeddings
+
+
+embeddings = SentenceTransformerEmbeddings(model_name=EMBEDDING_MODEL)
+
+
+def _load_cases(path: Path) -> List[dict]:
+    with path.open("r", encoding="utf-8") as handle:
+        return [json.loads(line) for line in handle]
+
+
+def _parse_date(value: str | None):
+    if not value:
+        return None
+    for fmt in ("%Y-%m-%d", "%Y.%m.%d", "%Y/%m/%d"):
+        try:
+            return datetime.strptime(value, fmt).date()
+        except ValueError:
+            continue
+    return None
+
+
+def ingest_precedents(cases: Iterable[dict]) -> None:
+    with closing(get_db_connection()) as conn:
+        with conn.cursor() as cur:
+            for case in track(list(cases), description="Ingesting precedents"):
+                cur.execute(
+                    """
+                    INSERT INTO precedent (court, case_no, date, title, summary, meta)
+                    VALUES (%s, %s, %s, %s, %s, %s)
+                    RETURNING case_id
+                    """,
+                    (
+                        case.get("court"),
+                        case.get("case_no"),
+                        _parse_date(case.get("date")),
+                        case.get("title"),
+                        case.get("summary"),
+                        json.dumps(case.get("meta", {})),
+                    ),
+                )
+                case_id = cur.fetchone()[0]
+
+                sections = case.get("sections") or []
+                section_texts = [section.get("text", "") for section in sections]
+                vectors = embeddings.embed_documents(section_texts) if section_texts else []
+
+                for idx, section in enumerate(sections):
+                    text = section.get("text", "")
+                    if not text.strip():
+                        continue
+                    cur.execute(
+                        """
+                        INSERT INTO precedent_section (case_id, position, heading, text, meta)
+                        VALUES (%s, %s, %s, %s, %s)
+                        RETURNING section_id
+                        """,
+                        (
+                            case_id,
+                            idx,
+                            section.get("heading"),
+                            text,
+                            json.dumps(section.get("meta", {})),
+                        ),
+                    )
+                    section_id = cur.fetchone()[0]
+                    cur.execute(
+                        """
+                        INSERT INTO precedent_section_embedding (section_id, model_name, dim, embedding)
+                        VALUES (%s, %s, %s, %s)
+                        """,
+                        (
+                            section_id,
+                            EMBEDDING_MODEL,
+                            EMBEDDING_DIM,
+                            vectors[idx],
+                        ),
+                    )
+        conn.commit()
+
+
+def main() -> None:
+    if len(sys.argv) != 2:
+        print("[red]Usage: python batch_learn.py <precedents.jsonl>[/red]")
+        sys.exit(1)
+
+    path = Path(sys.argv[1])
+    if not path.exists():
+        print(f"[red]파일을 찾을 수 없습니다: {path}[/red]")
+        sys.exit(1)
+
+    cases = _load_cases(path)
+    if not cases:
+        print("[yellow]처리할 사건이 없습니다.[/yellow]")
         return
-    except json.JSONDecodeError:
-        console.console.print(f"[bold red]오류: 파일이 올바른 JSONL 형식이 아닙니다 - {filepath}[/bold red]")
-        return
-    
-    console.console.print(f"총 {len(cases)}개의 사건을 학습합니다.\n")
 
-    for i, case in enumerate(cases):
-        case_id = case.get("caseId", "N/A")
-        plaintiff_statement = case.get("plaintiff_statement", "")
-        defendant_statement = case.get("defendant_statement", "")
+    print(f"[cyan]총 {len(cases)}건의 판례를 적재합니다.[/cyan]")
+    ingest_precedents(cases)
+    print("[green]판례 적재가 완료되었습니다.[/green]")
 
-        console.console.print(Rule(f"[bold]사건 {i+1}/{len(cases)} 처리 중 (ID: {case_id})[/bold]"))
-
-        # 1. 모의 판결 생성
-        console.console.print("1. 재판장 에이전트가 모의 판결 생성 중...")
-        verdict_response = batch_judge_chain.invoke({
-            "plaintiff_statement": plaintiff_statement,
-            "defendant_statement": defendant_statement
-        })
-        final_verdict = verdict_response.content.strip()
-        console.print_final_verdict(final_verdict)
-
-        # 2. 승패 분석
-        console.console.print("2. 평가 에이전트가 승패 분석 중...")
-        evaluation_response = evaluation_chain.invoke({"final_verdict": final_verdict})
-        plaintiff_outcome = evaluation_response.content.strip()
-        defendant_outcome = "승리" if plaintiff_outcome == "패배" else ("패배" if plaintiff_outcome == "승리" else "무승부")
-        
-        outcomes = {
-            "원고측 변호사": {"outcome": plaintiff_outcome, "db_key_prefix": "plaintiff_lawyer", "speech": plaintiff_statement},
-            "피고측 변호사": {"outcome": defendant_outcome, "db_key_prefix": "defendant_lawyer", "speech": defendant_statement}
-        }
-        
-        lessons = {}
-        
-        # 3. 양측 교훈 도출
-        console.console.print("3. 회고 에이전트가 교훈 도출 중...")
-        for lawyer_name, info in outcomes.items():
-            reflection_response = reflection_chain.invoke({
-                "outcome": info['outcome'],
-                "my_speeches": info['speech']
-            })
-            lesson = reflection_response.content.strip()
-            lessons[info['db_key_prefix']] = lesson
-            console.print_lesson(lawyer_name, info['outcome'], lesson)
-            
-            # 4. 개인 DB (Redis) 업데이트
-            if info['outcome'] == "승리":
-                redis_client.rpush(f"{info['db_key_prefix']}:successful_strategies", lesson)
-            elif info['outcome'] == "패배":
-                redis_client.rpush(f"{info['db_key_prefix']}:failed_strategies", lesson)
-
-        # 5. 사건 아카이브 (PostgreSQL) 업데이트
-        case_summary = f"원고 주장: {plaintiff_statement[:100]}...\n피고 주장: {defendant_statement[:100]}..."
-        add_case_to_db(
-            case_summary=case_summary,
-            verdict=final_verdict,
-            plaintiff_lesson=lessons.get("plaintiff_lawyer", ""),
-            defendant_lesson=lessons.get("defendant_lawyer", "")
-        )
-        
-        # API 속도 제한 방지를 위해 잠시 대기
-        time.sleep(1) 
-
-    console.print_header("데이터셋 일괄 학습 완료")
 
 if __name__ == "__main__":
-    # 현재 스크립트 파일의 위치를 기준으로 데이터 파일 경로 설정
-    current_dir = os.path.dirname(os.path.abspath(__file__))
-    dataset_path = os.path.join(current_dir, "data", "train.jsonl")
-    run_batch_learning(dataset_path)
+    main()

--- a/benchmark.py
+++ b/benchmark.py
@@ -1,200 +1,110 @@
+"""Lightweight benchmarking harness for the new assistant workflow."""
+from __future__ import annotations
+
 import argparse
 import csv
 import json
-import os
-import time
-from collections import defaultdict
 from datetime import datetime
-from typing import Dict, List, Tuple
+from pathlib import Path
+from typing import Dict, List
 
-from rich.rule import Rule
+from rich import print
 from rich.table import Table
 
-import src.console as console
-from src.agents import CRITIQUE_CRITERIA, redis_client
 from src.graph import app
-from src.vector_db import vector_store
-
-CRITERIA_HEADERS: Dict[str, Tuple[str, str]] = {
-    "논리적 일관성": ("logical_consistency_score", "logical_consistency_reason"),
-    "법률적 타당성": ("legal_validity_score", "legal_validity_reason"),
-    "사회적 가치 고려": ("social_consideration_score", "social_consideration_reason"),
-}
 
 
-def run_benchmark(test_filepath: str, is_trained: bool):
-    """주어진 테스트 데이터셋으로 벤치마크를 수행하고, 결과를 CSV로 저장합니다."""
-    mode = "학습 후 (Trained)" if is_trained else "학습 전 (Untrained)"
-    console.print_header(f"벤치마크 테스트 시작: {mode}")
+def _load_cases(path: Path) -> List[dict]:
+    with path.open("r", encoding="utf-8") as handle:
+        return [json.loads(line) for line in handle]
 
-    if not is_trained:
-        console.console.print("[bold yellow]경고: 모든 DB(Redis, PostgreSQL)의 데이터를 초기화합니다.[/bold yellow]")
-        redis_client.flushall()
-        console.console.print("🔴 Redis DB가 초기화되었습니다.")
-        try:
-            vector_store.delete_collection()
-            console.console.print("🔴 PostgreSQL 벡터 DB가 초기화되었습니다.")
-        except Exception as e:
-            console.console.print(f"🟡 PostgreSQL 벡터 DB 초기화 중 참고: {e}")
-    else:
-        console.console.print("사전 학습된 DB를 사용하여 성능을 측정합니다.")
 
-    try:
-        with open(test_filepath, "r", encoding="utf-8") as f:
-            test_cases = [json.loads(line) for line in f]
-    except FileNotFoundError:
-        console.console.print(f"[bold red]오류: 테스트 파일을 찾을 수 없습니다 - {test_filepath}[/bold red]")
+def run_benchmark(dataset_path: Path, firm_id: int, user_id: int) -> None:
+    cases = _load_cases(dataset_path)
+    if not cases:
+        print("[yellow]평가할 데이터가 없습니다.[/yellow]")
         return
 
     timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
-    results_filename = f"benchmark_results_{mode.replace(' ', '_')}_{timestamp}.csv"
+    output_file = dataset_path.with_name(f"benchmark_results_{timestamp}.csv")
 
-    with open(results_filename, "w", newline="", encoding="utf-8-sig") as f:
-        writer = csv.writer(f)
-        header = [
+    with output_file.open("w", newline="", encoding="utf-8-sig") as handle:
+        fieldnames = [
             "case_id",
-            "expected_outcome",
-            "model_outcome",
-            "is_correct",
-            "logical_consistency_score",
-            "logical_consistency_reason",
-            "legal_validity_score",
-            "legal_validity_reason",
-            "social_consideration_score",
-            "social_consideration_reason",
+            "summary",
+            "issues",
+            "draft_text",
+            "simulation_report",
         ]
-        writer.writerow(header)
+        writer = csv.DictWriter(handle, fieldnames=fieldnames)
+        writer.writeheader()
 
-        total_scores = defaultdict(float)
-        total_runs = 0
-        paired_outcomes: List[Tuple[str, str]] = []
+        for case in cases:
+            case_id = case.get("case_id") or case.get("id")
+            document_text = case.get("document_text") or case.get("text")
+            if not document_text:
+                print(f"[red]문서 내용이 비어 있는 케이스를 건너뜁니다: {case_id}[/red]")
+                continue
 
-        for i, case in enumerate(test_cases):
-            case_id = case.get("caseId", "N/A")
-            console.console.print(Rule(f"[bold]테스트 케이스 {i + 1}/{len(test_cases)} 실행 (ID: {case_id})[/bold]"))
-
-            initial_state = {
-                "case_file": f"원고 주장: {case['plaintiff_statement']}\n피고 주장: {case['defendant_statement']}",
-                "plaintiff_lawyer": "원고측 변호사",
-                "defendant_lawyer": "피고측 변호사",
+            state = {
+                "firm_id": firm_id,
+                "user_id": user_id,
+                "file_name": f"benchmark_{case_id or 'unknown'}.txt",
+                "mime_type": "text/plain",
+                "file_bytes": document_text.encode("utf-8"),
+                "enable_ocr": False,
+                "user_feedback": None,
             }
 
-            final_event = None
-            for event in app.stream(initial_state):
-                if "__end__" in event:
-                    final_event = event["__end__"]
+            final_state: Dict[str, object] = {}
+            for event in app.stream(state):
+                final_state.update(event)
 
-            final_state = final_event or {}
-            critique_scores = final_state.get("critique_scores", []) or []
-            model_outcome = final_state.get("plaintiff_outcome")
-            expected_outcome = case.get("expected_outcome")
+            writer.writerow(
+                {
+                    "case_id": case_id or "N/A",
+                    "summary": final_state.get("summarize", {}).get("summary"),
+                    "issues": " | ".join(final_state.get("summarize", {}).get("issues", [])),
+                    "draft_text": final_state.get("draft", {}).get("draft_text"),
+                    "simulation_report": final_state.get("simulate", {}).get("simulation_report"),
+                }
+            )
 
-            row_data: Dict[str, object] = {
-                "case_id": case_id,
-                "expected_outcome": expected_outcome or "N/A",
-                "model_outcome": (model_outcome or ("미예측" if expected_outcome else "N/A")),
-                "is_correct": "N/A",
-            }
+    print(f"[green]벤치마크 결과가 {output_file}에 저장되었습니다.[/green]")
 
-            for criteria, (score_key, reason_key) in CRITERIA_HEADERS.items():
-                row_data[score_key] = 0
-                row_data[reason_key] = "평가 결과가 기록되지 않았습니다."
+    table = Table(title="샘플 결과 미리보기", show_lines=True)
+    table.add_column("케이스 ID", style="cyan")
+    table.add_column("요약", style="white", max_width=50, overflow="fold")
+    table.add_column("주요 쟁점", style="magenta", max_width=30, overflow="fold")
+    table.add_column("반론 시뮬레이션", style="green", max_width=40, overflow="fold")
 
-            for item in critique_scores:
-                criteria = item.get("criteria")
-                if criteria not in CRITERIA_HEADERS:
-                    continue
-                score_key, reason_key = CRITERIA_HEADERS[criteria]
-                score = int(item.get("score", 0))
-                reason = item.get("reason") or "평가 이유가 제공되지 않았습니다."
-                row_data[score_key] = score
-                row_data[reason_key] = reason
-                total_scores[criteria] += score
+    with output_file.open("r", encoding="utf-8-sig") as handle:
+        reader = csv.DictReader(handle)
+        for row in list(reader)[:5]:
+            table.add_row(
+                row["case_id"],
+                row["summary"] or "-",
+                row["issues"] or "-",
+                row["simulation_report"] or "-",
+            )
 
-            if expected_outcome:
-                predicted_label = model_outcome or "미예측"
-                paired_outcomes.append((expected_outcome, predicted_label))
-                if model_outcome:
-                    row_data["is_correct"] = "Y" if expected_outcome == model_outcome else "N"
-                else:
-                    row_data["is_correct"] = "N"
-            elif model_outcome:
-                row_data["is_correct"] = "정보 부족"
+    print(table)
 
-            writer.writerow([row_data.get(h, "N/A") for h in header])
-            total_runs += 1
-            time.sleep(1)
 
-    console.print_header(f"벤치마크 테스트 완료: {mode}")
-    console.console.print(f"결과가 [bold cyan]{results_filename}[/bold cyan] 파일에 저장되었습니다.")
+def main() -> None:
+    parser = argparse.ArgumentParser(description="새로운 법률 어시스턴트 파이프라인 벤치마크")
+    parser.add_argument("dataset", type=str, help="평가할 JSONL 데이터셋 경로")
+    parser.add_argument("--firm-id", type=int, default=1)
+    parser.add_argument("--user-id", type=int, default=1)
+    args = parser.parse_args()
 
-    table = Table(title="평균 점수 (Pass 비율)")
-    table.add_column("평가 항목", justify="right", style="cyan", no_wrap=True)
-    table.add_column("평균 점수 (%)", justify="center", style="magenta")
+    dataset_path = Path(args.dataset)
+    if not dataset_path.exists():
+        print(f"[red]데이터셋을 찾을 수 없습니다: {dataset_path}[/red]")
+        return
 
-    if total_runs > 0:
-        for criteria in CRITIQUE_CRITERIA:
-            avg_score = (total_scores[criteria] / total_runs) * 100 if total_runs else 0.0
-            table.add_row(criteria, f"{avg_score:.2f}%")
-
-    console.console.print(table)
-
-    accuracy = 0.0
-    macro_f1 = 0.0
-    expected_win_rate = 0.0
-    model_win_rate = 0.0
-    per_label_metrics: List[Tuple[str, float, float, float]] = []
-
-    if paired_outcomes:
-        total_cases = len(paired_outcomes)
-        correct_predictions = sum(1 for expected, predicted in paired_outcomes if expected == predicted)
-        accuracy = correct_predictions / total_cases
-        expected_win_rate = sum(1 for expected, _ in paired_outcomes if expected == "승리") / total_cases
-        model_win_rate = sum(1 for _, predicted in paired_outcomes if predicted == "승리") / total_cases
-        labels = sorted({expected for expected, _ in paired_outcomes})
-        if labels:
-            f1_sum = 0.0
-            for label in labels:
-                tp = sum(1 for expected, predicted in paired_outcomes if expected == label and predicted == label)
-                fp = sum(1 for expected, predicted in paired_outcomes if expected != label and predicted == label)
-                fn = sum(1 for expected, predicted in paired_outcomes if expected == label and predicted != label)
-                precision = tp / (tp + fp) if (tp + fp) else 0.0
-                recall = tp / (tp + fn) if (tp + fn) else 0.0
-                f1 = (2 * precision * recall / (precision + recall)) if (precision + recall) else 0.0
-                f1_sum += f1
-                per_label_metrics.append((label, precision, recall, f1))
-            macro_f1 = f1_sum / len(labels) if labels else 0.0
-
-    metrics_table = Table(title="판결 결과 정량 지표")
-    metrics_table.add_column("지표", justify="left", style="green")
-    metrics_table.add_column("값", justify="center", style="white")
-    metrics_table.add_row("정확도 (Accuracy)", f"{accuracy * 100:.2f}%")
-    metrics_table.add_row("Macro F1", f"{macro_f1:.4f}")
-    metrics_table.add_row("예상 원고 승소율", f"{expected_win_rate * 100:.2f}%")
-    metrics_table.add_row("모델 원고 승소율", f"{model_win_rate * 100:.2f}%")
-    console.console.print(metrics_table)
-
-    if per_label_metrics:
-        label_table = Table(title="클래스별 Precision/Recall/F1")
-        label_table.add_column("라벨", style="cyan")
-        label_table.add_column("Precision", justify="center")
-        label_table.add_column("Recall", justify="center")
-        label_table.add_column("F1", justify="center")
-        for label, precision, recall, f1 in per_label_metrics:
-            label_table.add_row(label, f"{precision:.2f}", f"{recall:.2f}", f"{f1:.2f}")
-        console.console.print(label_table)
+    run_benchmark(dataset_path, firm_id=args.firm_id, user_id=args.user_id)
 
 
 if __name__ == "__main__":
-    parser = argparse.ArgumentParser(description="모의 법정 시스템 벤치마크 테스트")
-    parser.add_argument("--mode", type=str, required=True, choices=["trained", "untrained"],
-                        help="'trained' 또는 'untrained' 모드를 선택하세요.")
-    args = parser.parse_args()
-
-    current_dir = os.path.dirname(os.path.abspath(__file__))
-    test_dataset_path = os.path.join(current_dir, "data", "test.jsonl")
-
-    if args.mode == "untrained":
-        run_benchmark(test_dataset_path, is_trained=False)
-    else:
-        run_benchmark(test_dataset_path, is_trained=True)
+    main()

--- a/demo.py
+++ b/demo.py
@@ -1,12 +1,14 @@
 # 파일명: demo.py (프로젝트 최상위 폴더에 생성)
 import streamlit as st
-import os
 from dotenv import load_dotenv
 from src.db_utils import get_db_connection, set_rls_user
-from src.file_processor import process_and_embed_file, EMBEDDING_DIM
-from src.vector_db import search_private_chunks, search_public_statutes
+from src.file_processor import EMBEDDING_DIM, ingest_document
+from src.vector_db import (
+    search_private_chunks,
+    search_public_precedents,
+    search_public_statutes,
+)
 from src.llm_client import get_rag_answer
-import psycopg2
 
 # .env 파일 로드 (OPENAI_API_KEY, DB 접속 정보 등)
 load_dotenv()
@@ -70,19 +72,25 @@ if uploaded_file:
     if st.button(f"'{uploaded_file.name}' 처리 및 임베딩"):
         with st.spinner("파일을 파싱하고 임베딩하여 '전용 DB'에 저장 중입니다... (시간이 걸릴 수 있습니다)"):
             try:
-                doc_id, chunk_count = process_and_embed_file(
-                    st.session_state.conn,
-                    st.session_state.firm_id,
-                    st.session_state.user_id,
-                    uploaded_file
+                parsed, stored = ingest_document(
+                    firm_id=st.session_state.firm_id,
+                    user_id=st.session_state.user_id,
+                    file_bytes=uploaded_file.getvalue(),
+                    file_name=uploaded_file.name,
+                    mime_type=uploaded_file.type,
+                    conn=st.session_state.conn,
                 )
-                st.success(f"파일 처리 완료! (문서 ID: {doc_id}, 청크 수: {chunk_count})")
+                st.success(
+                    f"파일 처리 완료! (문서 ID: {stored.doc_id}, 청크 수: {len(parsed.chunks)})"
+                )
             except Exception as e:
                 st.error(f"파일 처리 중 오류 발생: {e}")
 
 # --- 3. RAG 기반 질의응답 ---
 st.header("2. RAG 기반 질의응답")
-st.info(f"업로드한 '전용 문서'와 '공용 법령'을 모두 검색하여 답변합니다. (임베딩 차원: {EMBEDDING_DIM})")
+st.info(
+    f"업로드한 '전용 문서'와 '공용 법령/판례'를 모두 검색하여 답변합니다. (임베딩 차원: {EMBEDDING_DIM})"
+)
 
 query = st.text_input("질문:", placeholder="업로드한 문서의 내용을 요약해줘")
 
@@ -91,9 +99,10 @@ if query:
         try:
             # RAG 검색 (전용 DB + 공용 DB)
             private_results = search_private_chunks(st.session_state.conn, query, top_k=3)
-            public_results = search_public_statutes(st.session_state.conn, query, top_k=2)
-            
-            context_chunks = private_results + public_results
+            statute_results = search_public_statutes(st.session_state.conn, query, top_k=2)
+            precedent_results = search_public_precedents(st.session_state.conn, query, top_k=2)
+
+            context_chunks = private_results + statute_results + precedent_results
             
             if not context_chunks:
                 st.warning("관련된 참고 자료를 찾지 못했습니다. LLM이 부정확하게 답변할 수 있습니다.")

--- a/init.sql
+++ b/init.sql
@@ -222,7 +222,7 @@ CREATE POLICY chunk_firm_isolation ON doc_chunk
 
 DROP POLICY IF EXISTS private_meta_firm_isolation ON private_case_meta;
 CREATE POLICY private_meta_firm_isolation ON private_case_meta
-  USING (firm_id = current_setting('app.firm_id', true)::BIGGINT);
+  USING (firm_id = current_setting('app.firm_id', true)::BIGINT);
 
 DROP POLICY IF EXISTS fb_firm_isolation ON feedback;
 CREATE POLICY fb_firm_isolation ON feedback

--- a/main.py
+++ b/main.py
@@ -1,19 +1,43 @@
+"""Command line entry point to demonstrate the assistant workflow."""
+from __future__ import annotations
+
+from rich import print
+
 from src.graph import app
 
 if __name__ == "__main__":
-    print("🚀 모의 법정 시뮬레이션을 시작합니다.")
+    sample_document = (
+        "원고는 아파트 층간소음으로 정신적 손해를 입었다고 주장하며 피고에게 위자료 지급을 청구한다. "
+        "피고는 적법한 방음 공사를 수행했고 공동주택관리규약을 준수했다고 항변한다."
+    )
 
-    # 초기 재판 정보 설정
     initial_state = {
-        "case_file": "아파트 층간소음으로 인한 손해배상 청구",
-        "plaintiff_lawyer": "원고측 변호사",
-        "defendant_lawyer": "피고측 변호사",
+        "firm_id": 1,
+        "user_id": 1,
+        "file_name": "sample_case.txt",
+        "mime_type": "text/plain",
+        "file_bytes": sample_document.encode("utf-8"),
+        "enable_ocr": False,
     }
 
-    # 그래프 실행 및 결과 스트리밍
+    print("[bold cyan]🚀 B2B 법률 AI 어시스턴트 파이프라인을 실행합니다.[/bold cyan]")
+
     for event in app.stream(initial_state):
-        for key, value in event.items():
-            print(f"\n--- Node '{key}' 완료 ---")
-            # 각 단계의 상세 결과를 보려면 아래 주석을 해제하세요.
-            # print(value) 
-            print("-" * 25)
+        for node, value in event.items():
+            print(f"\n[green]노드 '{node}' 완료[/green]")
+            if node == "summarize":
+                print(f"요약: {value.get('summary')}")
+                print(f"쟁점: {value.get('issues')}")
+            elif node == "rag":
+                print("참조 근거:")
+                for item in value.get("rag_results", []):
+                    print(f"  - {item['source']}")
+            elif node == "draft":
+                print("초안 미리보기:")
+                print(value.get("draft_text", ""))
+            elif node == "simulate":
+                print("시뮬레이션 결과:")
+                print(value.get("simulation_report", ""))
+            elif node == "feedback":
+                saved = value.get("feedback_saved")
+                print(f"피드백 저장 여부: {saved}")

--- a/src/agents.py
+++ b/src/agents.py
@@ -1,232 +1,134 @@
+"""LLM prompt factories and reusable chains for the legal assistant."""
+from __future__ import annotations
+
 import os
-from typing import List, Literal
+from functools import lru_cache
+from typing import Tuple
 
-import redis
 from dotenv import load_dotenv
+from langchain_core.language_models.chat_models import BaseChatModel
 from langchain_core.prompts import ChatPromptTemplate
-from langchain_openai import ChatOpenAI
-from pydantic import BaseModel, Field
-__all__ = (
-    "llm",
-    "redis_client",
-    "lawyer_chain",
-    "judge_chain",
-    "presiding_judge_chain",
-    "batch_judge_chain",
-    "evaluation_chain",
-    "reflection_chain",
-    "critic_chain",
-    "CRITIQUE_CRITERIA",
-    "JUDGE_PERSONALITY_POOL",
-)
+from langchain_core.runnables import Runnable
 
-# .env 파일에서 환경 변수 로드
 load_dotenv()
 
-# OPENAI_API_KEY가 설정되지 않았다면 오류 메시지와 함께 종료
-if not os.getenv("OPENAI_API_KEY"):
-    raise ValueError("환경 변수에 OPENAI_API_KEY가 설정되지 않았습니다. .env 파일을 확인해주세요.")
-
-# 사용할 LLM 모델 설정
-llm = ChatOpenAI(model="gpt-4o", temperature=0.7)
-
-
-class CritiqueItem(BaseModel):
-    """판결 품질 평가 항목을 구조화한 스키마."""
-
-    criteria: Literal["논리적 일관성", "법률적 타당성", "사회적 가치 고려"] = Field(
-        ...,
-        description="평가 기준 이름",
-    )
-    score: Literal[0, 1] = Field(
-        ...,
-        description="기준 충족 여부. 충족 시 1, 미충족 시 0",
-    )
-    reason: str = Field(
-        ...,
-        min_length=1,
-        description="해당 점수를 부여한 이유",
-    )
+__all__ = (
+    "build_chat_model",
+    "llm",
+    "summarize_chain",
+    "rag_response_chain",
+    "draft_chain",
+    "simulation_chain",
+    "format_references_for_prompt",
+)
 
 
-class CritiqueEvaluation(BaseModel):
-    """세 가지 기준에 대한 평가 결과 목록."""
+def build_chat_model() -> BaseChatModel:
+    """Return a chat model instance based on runtime configuration."""
 
-    evaluations: List[CritiqueItem] = Field(
-        ...,
-        min_items=3,
-        description="각 기준별 평가 결과 목록",
-    )
+    provider = os.getenv("LLM_PROVIDER", "").strip().lower()
+    temperature = float(os.getenv("LLM_TEMPERATURE", "0.2"))
+
+    if provider == "openai" or (not provider and os.getenv("OPENAI_API_KEY")):
+        from langchain_openai import ChatOpenAI
+
+        model_name = os.getenv("OPENAI_MODEL", "gpt-4o-mini")
+        return ChatOpenAI(model=model_name, temperature=temperature)
+
+    # Default to Ollama-compatible local models to satisfy on-prem requirements.
+    base_url = os.getenv("OLLAMA_BASE_URL", "http://localhost:11434")
+    model_name = os.getenv("OLLAMA_MODEL", "llama3")
+    try:
+        from langchain_community.chat_models import ChatOllama
+    except ImportError as exc:  # pragma: no cover - import guard
+        raise RuntimeError(
+            "ChatOllama is not available. Install langchain-community with Ollama support "
+            "or set LLM_PROVIDER=openai with a valid OPENAI_API_KEY."
+        ) from exc
+
+    return ChatOllama(model=model_name, temperature=temperature, base_url=base_url)
 
 
-CRITIQUE_CRITERIA: List[str] = [
-    "논리적 일관성",
-    "법률적 타당성",
-    "사회적 가치 고려",
-]
+@lru_cache(maxsize=1)
+def _cached_llm() -> BaseChatModel:
+    return build_chat_model()
 
-# ------------------- 데이터베이스 클라이언트 -------------------
-redis_client = redis.Redis(host='localhost', port=6379, db=0, decode_responses=True)
 
-# ------------------- 변호사 에이전트 -------------------
-lawyer_prompt_template = """
-# 역할(Role)
-당신은 {client_type}을(를) 대리하는 유능한 변호사입니다.
+llm: BaseChatModel = _cached_llm()
 
-# 목표(Goal)
-당신의 목표는 주어진 사건 파일과 재판의 맥락을 완벽하게 파악하여, 의뢰인에게 '가장 유리하고 현실적인 결과'를 이끌어 내는 것입니다.
-- 만약 의뢰인의 책임이 명백한 상황이라면, 무조건적인 무죄나 승소를 주장하는 대신, '책임과 손해를 최소화'하는 방향으로 변론을 이끌어야 합니다.
-- 불필요한 억지 주장을 펼쳐 재판부에 나쁜 인상을 주지 않도록 주의해야 합니다.
+# ---------------------------------------------------------------------------
+# Prompt templates
+# ---------------------------------------------------------------------------
 
-# 행동 강령(Code of Conduct)
-1.  **근거 기반 주장**: 모든 주장은 사건 파일에 명시된 사실이나 증거에 기반해야 합니다.
-2.  **논리적 반박**: 상대 변호사의 주장을 먼저 요약하고, 그 주장의 논리적 허점을 명확하게 반박하세요.
-3.  **핵심 집중**: 사건의 핵심 쟁점에서 벗어나는 발언은 최소화하세요.
-4.  **과거 경험 학습**: 아래 '과거 재판의 교훈'을 참고하여 성공 전략은 강화하고, 실패 전략은 피하세요.
-5.  **유사 사건 참고**: 아래 '유사 과거 사건' 정보를 현재 사건과 비교하여 변론 전략을 세우세요.
-
----
-[사건 파일]
-{case_file}
-
-[유사 과거 사건]
-{similar_cases}
-
-[과거 재판의 교훈 (개인 DB)]
-{past_lessons}
-
-[이전 토론 기록]
-{transcript}
----
-위 정보를 바탕으로, 이제 당신의 차례입니다. 의뢰인을 위해 최고의 변론을 펼치세요.
-"""
-lawyer_prompt = ChatPromptTemplate.from_template(lawyer_prompt_template)
-lawyer_chain = lawyer_prompt | llm
-
-# ------------------- 서브 판사 에이전트 -------------------
-judge_prompt_template = """
-# 역할(Role)
-당신은 합의부의 서브 판사입니다. 당신의 판단 스타일은 다음과 같습니다.
-- 이름: {judge_name}
-- 판단 기준: {judge_description}
-# 임무(Mission)
-아래의 변호사 토론 기록 전체를 읽고, 당신의 '판단 기준'에 입각하여 이 사건에 대한 당신의 의견을 한 문단으로 명확하게 제시하세요.
----
-[변호사 토론 기록]
-{transcript}
----
-[당신의 의견]
-"""
-judge_prompt = ChatPromptTemplate.from_template(judge_prompt_template)
-judge_chain = judge_prompt | llm
-
-# ------------------- 재판장 에이전트 -------------------
-presiding_judge_prompt_template = """
-# 역할(Role)
-당신은 재판을 총괄하는 재판장입니다.
-# 임무(Mission)
-당신의 임무는 아래에 제시된 '변호사 토론 기록'과 '서브 판사들의 의견'을 모두 종합하여, 최종 판결문을 작성하는 것입니다.
-판결문은 반드시 "주문:"으로 시작하고, 간결하고 명확한 판결 요지를 담아야 합니다.
----
-[변호사 토론 기록]
-{transcript}
-[서브 판사들의 의견]
-{judge_verdicts}
----
-[최종 판결문]
-"""
-presiding_judge_prompt = ChatPromptTemplate.from_template(presiding_judge_prompt_template)
-presiding_judge_chain = presiding_judge_prompt | llm
-
-# ------------------- 일괄 판결 생성 에이전트 -------------------
-batch_judge_prompt_template = """
-# 역할(Role)
-당신은 재판을 주재하는 판사입니다.
-# 임무(Mission)
-아래에 주어진 원고와 피고의 진술을 바탕으로 사건의 쟁점을 정리하고, 최종 판결문을 작성하세요.
-판결문은 반드시 "주문:"으로 시작해야 하며, 핵심 판시 이유를 2~3문장으로 덧붙이세요.
-과도하게 긴 설명은 피하고 명확하고 간결하게 작성합니다.
----
-[원고측 진술]
-{plaintiff_statement}
-[피고측 진술]
-{defendant_statement}
----
-[최종 판결문]
-"""
-batch_judge_prompt = ChatPromptTemplate.from_template(batch_judge_prompt_template)
-batch_judge_chain = batch_judge_prompt | llm
-
-# ------------------- 학습/진화 에이전트 -------------------
-evaluation_prompt_template = """
-# 역할(Role)
-당신은 재판 분석가입니다.
-# 임무(Mission)
-아래의 최종 판결문을 분석하여 '원고' 입장에서의 승패 여부를 판단해주세요.
-- 원고의 청구가 전부 또는 대부분 받아들여졌다면 "승리"
-- 원고의 청구가 전부 또는 대부분 기각되었다면 "패배"
-- 그 외의 경우(일부 인용, 조정 등)는 "무승부"
-오직 "승리", "패배", "무승부" 중 하나의 단어로만 답변하세요.
----
-[최종 판결문]
-{final_verdict}
----
-[원고측 승패 여부]
-"""
-evaluation_prompt = ChatPromptTemplate.from_template(evaluation_prompt_template)
-evaluation_chain = evaluation_prompt | llm
-
-reflection_prompt_template = """
-# 역할(Role)
-당신은 변론 전략 코치입니다.
-# 임무(Mission)
-아래의 '재판 결과'와 '변론 내용'을 바탕으로, 이 변론에서 가장 유효했거나 혹은 가장 아쉬웠던 핵심 전략을 한 문장으로 요약하여 '교훈'을 도출해주세요.
----
-[재판 결과]
-{outcome}
-[자신의 변론 내용]
-{my_speeches}
----
-[핵심 전략 및 교훈]
-"""
-reflection_prompt = ChatPromptTemplate.from_template(reflection_prompt_template)
-reflection_chain = reflection_prompt | llm
-
-# ------------------- 비평가 에이전트 (논문 방식 적용) -------------------
-critic_prompt_template = """
-# 역할(Role)
-당신은 냉철하고 객관적인 법률 분석가입니다.
-# 임무(Mission)
-아래의 '변호사 토론 기록'과 '최종 판결문'을 읽고, 다음 세 가지 기준 각각에 대해 판결의 품질이 기준을 '충족'하는지 '미충족'하는지 판단해주세요.
-- 기준을 충족하면 score에 1, 미충족이면 0을 부여하세요.
-- 그 이유(reason)를 한 문장으로 간결하게 설명해주세요.
-결과는 반드시 하나의 JSON 객체로만 출력해야 하며, 아래 스키마를 따라야 합니다.
-{
-    "evaluations": [
-        {"criteria": "논리적 일관성", "score": 0 또는 1, "reason": "..."},
-        {"criteria": "법률적 타당성", "score": 0 또는 1, "reason": "..."},
-        {"criteria": "사회적 가치 고려", "score": 0 또는 1, "reason": "..."}
+summarize_prompt = ChatPromptTemplate.from_messages(
+    [
+        (
+            "system",
+            "You are a bilingual Korean legal analyst. Read the provided document text and "
+            "return a JSON object with two keys: 'summary' containing a concise Korean summary "
+            "and 'issues' containing a list (array) of the top legal issues extracted from the text.",
+        ),
+        ("human", "{document_text}"),
     ]
-}
-# 평가 기준
-1.  **논리적 일관성 (Logical Consistency)**: 변호사들의 주장과 최종 판결의 논리가 일관되는가?
-2.  **법률적 타당성 (Legal Validity)**: 판결이 법률 원칙과 상식적인 법 감정에 부합하는가?
-3.  **사회적 가치 고려 (Moral & Social Consideration)**: 판결이 법을 넘어선 윤리적, 사회적 가치를 충분히 고려하였는가?
----
-[변호사 토론 기록]
-{transcript}
-[최종 판결문]
-{final_verdict}
----
-"""
-critic_prompt = ChatPromptTemplate.from_template(critic_prompt_template)
-critic_chain = critic_prompt | llm.with_structured_output(CritiqueEvaluation)
+)
 
-# ------------------- 데이터 및 설정 -------------------
-JUDGE_PERSONALITY_POOL = [
-    {"name": "법리/판례 기반 판사", "description": "과거의 법률과 유사 판례에만 근거하여 판단합니다. 사회적 여론이나 개인적인 감정은 철저히 배제합니다."},
-    {"name": "윤리/도덕 기반 판사", "description": "법의 잣대를 넘어, 이 사건이 윤리적으로 어떤 의미를 갖는지, 그리고 더 정의로운 결정은 무엇인지 고심합니다."},
-    {"name": "사회적 이슈 기반 판사", "description": "이 판결이 사회에 미칠 영향과 현재의 사회적 통념 및 여론을 가장 중요한 판단 기준으로 삼습니다."},
-    {"name": "결과주의 판사", "description": "판결의 과정보다는, 어떤 판결이 궁극적으로 사회에 가장 큰 이익을 가져올 것인지 그 결과에만 집중합니다."},
-    {"name": "원칙주의 판사", "description": "어떤 상황에서든 예외를 허용하지 않으며, 정해진 법률 원칙을 고수하는 것을 최우선으로 생각합니다."}
-]
+rag_prompt = ChatPromptTemplate.from_messages(
+    [
+        (
+            "system",
+            "You are assisting a litigation lawyer. Given a matter description and retrieved legal "
+            "references, describe how each citation supports the case. Respond in JSON with the key "
+            "'analysis' containing a list of objects with 'source' and 'reasoning'.",
+        ),
+        (
+            "human",
+            "Matter summary: {summary}\n\nIssues: {issues}\n\nRetrieved references:\n{references}",
+        ),
+    ]
+)
+
+draft_prompt = ChatPromptTemplate.from_messages(
+    [
+        (
+            "system",
+            "You draft formal Korean legal briefs. Using the supplied summary, issues, and annotated "
+            "references, produce a structured draft with sections for 사실관계, 쟁점 및 법률근거, and 결론. "
+            "Cite each reference inline using [출처 n] notation where n is the index of the reference.",
+        ),
+        (
+            "human",
+            "Summary: {summary}\nIssues: {issues}\nReference analysis: {reference_analysis}",
+        ),
+    ]
+)
+
+simulation_prompt = ChatPromptTemplate.from_messages(
+    [
+        (
+            "system",
+            "You play the role of opposing counsel preparing counter arguments. Review the provided draft "
+            "and identify at least two potential rebuttals and unfavourable precedents. Return JSON with keys "
+            "'counter_arguments' (list of strings) and 'risky_precedents' (list of strings).",
+        ),
+        ("human", "Draft to challenge:\n{draft_text}"),
+    ]
+)
+
+
+# ---------------------------------------------------------------------------
+# Assembled chains
+# ---------------------------------------------------------------------------
+
+summarize_chain: Runnable = summarize_prompt | llm
+rag_response_chain: Runnable = rag_prompt | llm
+draft_chain: Runnable = draft_prompt | llm
+simulation_chain: Runnable = simulation_prompt | llm
+
+
+def format_references_for_prompt(references: Tuple[str, ...]) -> str:
+    """Utility to format reference snippets for prompt injection."""
+
+    lines = []
+    for idx, ref in enumerate(references, start=1):
+        lines.append(f"[{idx}] {ref}")
+    return "\n".join(lines)

--- a/src/file_processor.py
+++ b/src/file_processor.py
@@ -1,148 +1,286 @@
-# 파일명: src/file_processor.py (신규)
-import io
-import fitz  # PyMuPDF
-import docx # python-docx
-import hwp # pyhwp
+"""File ingestion helpers for the B2B legal assistant."""
+from __future__ import annotations
+
 import hashlib
-from langchain_community.embeddings import SentenceTransformerEmbeddings
+import io
+import json
+import logging
+import os
+import re
+from dataclasses import dataclass
+from typing import List, Optional, Tuple
+
+import fitz  # PyMuPDF
 from langchain.text_splitter import RecursiveCharacterTextSplitter
-from .db_utils import get_db_connection
+from langchain_community.embeddings import SentenceTransformerEmbeddings
 
-# 사용할 임베딩 모델 (requirements.txt에 sentence-transformers 필요)
-# all-MiniLM-L6-v2는 384 차원입니다.
-EMBEDDING_MODEL = "all-MiniLM-L6-v2" 
-EMBEDDING_DIM = 384
-# !!주의!!: init.sql의 모든 VECTOR(1024)를 VECTOR(384)로 수정해야 합니다.
+try:  # Optional dependency for DOCX parsing
+    import docx  # type: ignore
+except ImportError:  # pragma: no cover - optional dependency guard
+    docx = None
 
-embeddings = SentenceTransformerEmbeddings(model_name=EMBEDDING_MODEL)
+try:  # Optional dependency for HWP parsing
+    import pyhwp  # type: ignore
+except ImportError:  # pragma: no cover - optional dependency guard
+    pyhwp = None
 
-def get_text_splitter():
-    return RecursiveCharacterTextSplitter(
-        chunk_size=1000,
-        chunk_overlap=100,
-        length_function=len,
+from .db_utils import get_db_connection, set_rls_user
+
+# Module-level logger reserved for future debugging hooks (not used directly yet).
+logger = logging.getLogger(__name__)
+
+EMBEDDING_MODEL = os.getenv("EMBEDDING_MODEL", "all-MiniLM-L6-v2")
+EMBEDDING_DIM = int(os.getenv("EMBEDDING_DIM", "384"))
+
+_embeddings = SentenceTransformerEmbeddings(model_name=EMBEDDING_MODEL)
+_text_splitter = RecursiveCharacterTextSplitter(
+    chunk_size=int(os.getenv("CHUNK_SIZE", "1000")),
+    chunk_overlap=int(os.getenv("CHUNK_OVERLAP", "120")),
+    length_function=len,
+)
+
+
+@dataclass
+class ParsedChunk:
+    text: str
+    position: int
+    page_from: Optional[int] = None
+    page_to: Optional[int] = None
+    heading: Optional[str] = None
+
+
+@dataclass
+class ParsedDocument:
+    text: str
+    file_ext: str
+    mime_type: Optional[str]
+    page_count: int
+    byte_size: int
+    sha256: str
+    pii_flag: bool
+    chunks: List[ParsedChunk]
+    ocr_used: bool = False
+    ocr_engine: Optional[str] = None
+
+
+@dataclass
+class StoredDocument:
+    doc_id: int
+    revision_id: int
+    chunk_ids: List[int]
+    pii_flag: bool
+
+
+HANGUL_ID_PATTERN = re.compile(r"\b\d{6}-?[1-4]\d{6}\b")
+PHONE_PATTERN = re.compile(r"\b01[0-9]-?\d{3,4}-?\d{4}\b")
+ACCOUNT_PATTERN = re.compile(r"\b\d{2,4}-\d{2,4}-\d{2,6}\b")
+
+
+def _detect_pii(text: str) -> bool:
+    return bool(
+        HANGUL_ID_PATTERN.search(text)
+        or PHONE_PATTERN.search(text)
+        or ACCOUNT_PATTERN.search(text)
     )
 
-def parse_file(file_content, file_name, mime_type):
-    """파일 내용과 MIME 타입을 기반으로 텍스트를 추출합니다."""
-    text = ""
-    page_count = 0
-    file_ext = file_name.split('.')[-1].lower()
 
-    if file_ext == 'pdf':
-        with fitz.open(stream=file_content, filetype="pdf") as doc:
-            text = "".join(page.get_text() for page in doc)
-            page_count = doc.page_count
-    elif file_ext == 'docx':
-        doc = docx.Document(io.BytesIO(file_content))
-        text = "\n".join([para.text for para in doc.paragraphs])
-        page_count = 1 # docx는 페이지 계산이 복잡하므로 데모에선 1로 통일
-    elif file_ext == 'hwp':
-        # pyhwp는 BytesIO를 직접 지원하지 않을 수 있습니다. 
-        # 데모를 위해 임시 파일 저장이 필요할 수 있으나, BytesIO를 먼저 시도합니다.
-        try:
-            # pyhwp 사용 시 임시 파일 저장이 더 안정적일 수 있습니다.
-            # with open("temp.hwp", "wb") as f:
-            #     f.write(file_content)
-            # hwp_doc = hwp.open("temp.hwp")
-            # text = hwp_doc.get_text()
-            # os.remove("temp.hwp")
-            
-            hwp_doc = hwp.open(io.BytesIO(file_content))
-            text = hwp_doc.get_text()
-            page_count = 1 # hwp도 페이지 계산이 복잡
-        except Exception as e:
-            print(f"HWP 파싱 오류 (pyhwp는 파일 경로/임시 파일 저장이 필요할 수 있음): {e}")
-            text = "" # 오류 시 빈 텍스트 반환
-            
-    elif file_ext == 'txt':
-        try:
-            text = file_content.decode('utf-8')
-        except UnicodeDecodeError:
-            text = file_content.decode('euc-kr', errors='ignore') # 한글 깨짐 방지
-        page_count = 1
-        
-    # TODO: 스캔된 PDF/이미지의 경우 Naver OCR API 호출 로직 추가
+def _extract_pdf_text(file_bytes: bytes) -> Tuple[str, int]:
+    with fitz.open(stream=file_bytes, filetype="pdf") as doc:
+        pages = [page.get_text("text") for page in doc]
+        text = "\n".join(page.strip() for page in pages if page.strip())
+        return text, doc.page_count
 
-    return text, page_count, file_ext
 
-def process_and_embed_file(conn, firm_id, user_id, uploaded_file):
-    """
-    Streamlit의 UploadedFile 객체를 받아 파싱, 청킹, 임베딩, DB 저장을 수행합니다.
-    데모용으로 모든 작업을 동기식으로 처리합니다.
-    """
-    
-    file_content = uploaded_file.getvalue()
-    file_name = uploaded_file.name
-    mime_type = uploaded_file.type
-    
-    # 1. 파일 파싱
-    text, page_count, file_ext = parse_file(file_content, file_name, mime_type)
-    if not text:
-        raise ValueError("파일에서 텍스트를 추출할 수 없습니다. (HWP 파싱 오류 또는 빈 파일)")
+def _extract_docx_text(file_bytes: bytes) -> Tuple[str, int]:
+    if docx is None:  # pragma: no cover - optional dependency guard
+        raise RuntimeError("python-docx가 설치되어 있지 않습니다. requirements.txt를 확인하세요.")
 
-    # 2. 문서(Document) 레코드 생성
-    sha256 = hashlib.sha256(file_content).hexdigest()
-    bytes_size = len(file_content)
-    
+    document = docx.Document(io.BytesIO(file_bytes))
+    paragraphs = [para.text.strip() for para in document.paragraphs if para.text.strip()]
+    return "\n".join(paragraphs), max(1, len(paragraphs) // 40)
+
+
+def _extract_hwp_text(file_bytes: bytes) -> Tuple[str, int]:  # pragma: no cover - hwp files are rare in CI
+    if pyhwp is None:
+        raise RuntimeError("pyhwp 라이브러리가 설치되어 있지 않습니다. HWP 파일 처리를 위해 설치해주세요.")
+
+    # pyhwp는 파일 경로를 선호하기 때문에 임시 파일을 사용합니다.
+    import tempfile
+
+    with tempfile.NamedTemporaryFile(suffix=".hwp") as tmp:
+        tmp.write(file_bytes)
+        tmp.flush()
+        doc = pyhwp.HWPDocument(tmp.name)  # type: ignore[attr-defined]
+        sections = []
+        for section in doc.bodytext.section_list:  # type: ignore[attr-defined]
+            for paragraph in section.paragraph_list:  # type: ignore[attr-defined]
+                text = "".join(text.text for text in paragraph.text)  # type: ignore[attr-defined]
+                if text.strip():
+                    sections.append(text.strip())
+        return "\n".join(sections), max(1, len(sections) // 40)
+
+
+def parse_document(
+    file_bytes: bytes,
+    file_name: str,
+    mime_type: Optional[str] = None,
+    enable_ocr: bool = False,
+) -> ParsedDocument:
+    """Parse an uploaded document and return structured text chunks."""
+
+    file_ext = file_name.split(".")[-1].lower()
+    if file_ext == "pdf":
+        text, page_count = _extract_pdf_text(file_bytes)
+    elif file_ext == "docx":
+        text, page_count = _extract_docx_text(file_bytes)
+    elif file_ext == "hwp":
+        text, page_count = _extract_hwp_text(file_bytes)
+    elif file_ext == "txt":
+        text = file_bytes.decode("utf-8", errors="ignore")
+        page_count = max(1, len(text) // 2000)
+    else:
+        raise ValueError(f"지원하지 않는 파일 형식입니다: {file_ext}")
+
+    if not text.strip():
+        if enable_ocr:
+            raise NotImplementedError("OCR 엔진 연동이 아직 구현되지 않았습니다.")
+        raise ValueError("문서에서 텍스트를 추출할 수 없습니다. OCR 설정을 확인하세요.")
+
+    chunks: List[ParsedChunk] = []
+    for idx, chunk_text in enumerate(_text_splitter.split_text(text)):
+        chunks.append(ParsedChunk(text=chunk_text, position=idx))
+
+    sha256 = hashlib.sha256(file_bytes).hexdigest()
+    pii_flag = _detect_pii(text)
+
+    return ParsedDocument(
+        text=text,
+        file_ext=file_ext,
+        mime_type=mime_type,
+        page_count=page_count,
+        byte_size=len(file_bytes),
+        sha256=sha256,
+        pii_flag=pii_flag,
+        chunks=chunks,
+    )
+
+
+def store_document(
+    conn,
+    firm_id: int,
+    user_id: int,
+    title: str,
+    parsed: ParsedDocument,
+) -> StoredDocument:
+    """Persist the parsed document and its embeddings into PostgreSQL."""
+
     with conn.cursor() as cur:
         cur.execute(
             """
-            INSERT INTO document (firm_id, user_id, title, source_type, mime_type, file_ext, sha256, bytes, page_count)
-            VALUES (%s, %s, %s, 'upload', %s, %s, %s, %s, %s)
+            INSERT INTO document (firm_id, user_id, title, source_type, mime_type, file_ext, sha256, bytes, page_count, pii_flag)
+            VALUES (%s, %s, %s, 'upload', %s, %s, %s, %s, %s, %s)
             RETURNING doc_id
             """,
-            (firm_id, user_id, file_name, mime_type, file_ext, sha256, bytes_size, page_count)
+            (
+                firm_id,
+                user_id,
+                title,
+                parsed.mime_type,
+                parsed.file_ext,
+                parsed.sha256,
+                parsed.byte_size,
+                parsed.page_count,
+                parsed.pii_flag,
+            ),
         )
         doc_id = cur.fetchone()[0]
-        
-        # 데모용: 간단한 리비전 생성
+
         cur.execute(
             """
-            INSERT INTO document_revision (doc_id, revision_no, ocr_used)
-            VALUES (%s, 1, false) RETURNING rev_id
+            INSERT INTO document_revision (doc_id, revision_no, ocr_used, ocr_engine, parse_log)
+            VALUES (%s, 1, %s, %s, %s)
+            RETURNING rev_id
             """,
-            (doc_id,)
+            (
+                doc_id,
+                parsed.ocr_used,
+                parsed.ocr_engine,
+                json.dumps({"chunk_count": len(parsed.chunks)}),
+            ),
         )
         rev_id = cur.fetchone()[0]
 
-        # 3. 청킹
-        text_splitter = get_text_splitter()
-        chunks = text_splitter.split_text(text)
-        
-        chunk_ids = []
-        for i, chunk_text in enumerate(chunks):
+        chunk_ids: List[int] = []
+        for chunk in parsed.chunks:
             cur.execute(
                 """
-                INSERT INTO doc_chunk (doc_id, rev_id, position, text)
-                VALUES (%s, %s, %s, %s)
+                INSERT INTO doc_chunk (doc_id, rev_id, position, page_from, page_to, heading, text)
+                VALUES (%s, %s, %s, %s, %s, %s, %s)
                 RETURNING chunk_id
                 """,
-                (doc_id, rev_id, i, chunk_text)
+                (
+                    doc_id,
+                    rev_id,
+                    chunk.position,
+                    chunk.page_from,
+                    chunk.page_to,
+                    chunk.heading,
+                    chunk.text,
+                ),
             )
-            chunk_ids.append(cur.fetchone()[0])
+            chunk_id = cur.fetchone()[0]
+            chunk_ids.append(chunk_id)
 
-        # 4. 임베딩
-        chunk_embeddings = embeddings.embed_documents(chunks)
-        
-        for chunk_id, embedding_vector in zip(chunk_ids, chunk_embeddings):
-            # 참고: pgvector는 list를 받습니다.
+        embeddings = _embeddings.embed_documents([chunk.text for chunk in parsed.chunks])
+        for chunk_id, embedding_vector in zip(chunk_ids, embeddings):
             cur.execute(
                 """
                 INSERT INTO doc_chunk_embedding (chunk_id, model_name, dim, embedding)
                 VALUES (%s, %s, %s, %s)
                 """,
-                (chunk_id, EMBEDDING_MODEL, EMBEDDING_DIM, embedding_vector)
+                (
+                    chunk_id,
+                    EMBEDDING_MODEL,
+                    EMBEDDING_DIM,
+                    embedding_vector,
+                ),
             )
-            
-        # 5. 개인화 메타데이터 생성 (데모용)
+
         cur.execute(
             """
             INSERT INTO private_case_meta (doc_id, firm_id, user_id, case_type, tags)
-            VALUES (%s, %s, %s, '미분류', %s)
+            VALUES (%s, %s, %s, '미분류', ARRAY['자동업로드'])
+            ON CONFLICT (doc_id) DO NOTHING
             """,
-            (doc_id, firm_id, user_id, ['신규업로드'])
+            (doc_id, firm_id, user_id),
         )
-            
+
     conn.commit()
-    return doc_id, len(chunks)
+    return StoredDocument(doc_id=doc_id, revision_id=rev_id, chunk_ids=chunk_ids, pii_flag=parsed.pii_flag)
+
+
+def ingest_document(
+    firm_id: int,
+    user_id: int,
+    file_bytes: bytes,
+    file_name: str,
+    mime_type: Optional[str] = None,
+    enable_ocr: bool = False,
+    conn=None,
+) -> Tuple[ParsedDocument, StoredDocument]:
+    """High level helper used by LangGraph nodes to ingest a document."""
+
+    parsed = parse_document(file_bytes=file_bytes, file_name=file_name, mime_type=mime_type, enable_ocr=enable_ocr)
+    close_conn = False
+    if conn is None:
+        conn = get_db_connection()
+        close_conn = True
+
+    try:
+        set_rls_user(conn, firm_id)
+        stored = store_document(conn, firm_id, user_id, title=file_name, parsed=parsed)
+    finally:
+        if close_conn:
+            conn.close()
+
+    return parsed, stored

--- a/src/graph.py
+++ b/src/graph.py
@@ -1,41 +1,32 @@
-from langgraph.graph import StateGraph, END
-from src.state import TrialState
-from src.nodes import (
-    start_trial,
-    lawyer_debate_node,
-    associate_judge_deliberation_node,
-    final_judgment_node,
-    update_knowledge_base_node,
-    critique_node,
+"""LangGraph workflow definition for the legal assistant."""
+from __future__ import annotations
+
+from langgraph.graph import END, StateGraph
+
+from .nodes import (
+    drafting_node,
+    feedback_node,
+    ingest_node,
+    rag_chain_node,
+    simulation_node,
+    summarize_node,
 )
+from .state import AssistantState
 
-# 조건부 엣지를 위한 함수
-def should_continue_debate(state: TrialState):
-    return "continue_debate" if state['turn_count'] < state['max_turns'] else "end_debate"
+workflow = StateGraph(AssistantState)
+workflow.add_node("ingest", ingest_node)
+workflow.add_node("summarize", summarize_node)
+workflow.add_node("rag", rag_chain_node)
+workflow.add_node("draft", drafting_node)
+workflow.add_node("simulate", simulation_node)
+workflow.add_node("feedback", feedback_node)
 
-# 그래프 워크플로우 생성
-workflow = StateGraph(TrialState)
+workflow.set_entry_point("ingest")
+workflow.add_edge("ingest", "summarize")
+workflow.add_edge("summarize", "rag")
+workflow.add_edge("rag", "draft")
+workflow.add_edge("draft", "simulate")
+workflow.add_edge("simulate", "feedback")
+workflow.add_edge("feedback", END)
 
-# 노드 추가
-workflow.add_node("start_trial", start_trial)
-workflow.add_node("lawyer_debate", lawyer_debate_node)
-workflow.add_node("associate_judge_deliberation", associate_judge_deliberation_node)
-workflow.add_node("final_judgment", final_judgment_node)
-workflow.add_node("update_knowledge_base", update_knowledge_base_node)
-workflow.add_node("critique", critique_node)
-
-# 엣지(흐름) 연결
-workflow.set_entry_point("start_trial")
-workflow.add_edge("start_trial", "lawyer_debate")
-workflow.add_conditional_edges(
-    "lawyer_debate",
-    should_continue_debate,
-    {"continue_debate": "lawyer_debate", "end_debate": "associate_judge_deliberation"}
-)
-workflow.add_edge("associate_judge_deliberation", "final_judgment")
-workflow.add_edge("final_judgment", "update_knowledge_base")
-workflow.add_edge("update_knowledge_base", "critique")
-workflow.add_edge("critique", END)
-
-# 그래프 컴파일
 app = workflow.compile()

--- a/src/llm_client.py
+++ b/src/llm_client.py
@@ -1,11 +1,11 @@
-# 파일명: src/llm_client.py (신규)
-from langchain_openai import ChatOpenAI
-from langchain_core.prompts import ChatPromptTemplate
-from langchain_core.output_parsers import StrOutputParser
+"""Standalone helper functions for ad-hoc RAG prompts in the demo app."""
+from __future__ import annotations
 
-# 데모를 위해 OpenAI 모델을 사용합니다. (OPENAI_API_KEY 필요)
-# 로컬 모델(Llama 3, SOLAR)을 사용하려면 이 부분을 수정하세요.
-llm = ChatOpenAI(model="gpt-4o", temperature=0.1)
+from langchain_core.output_parsers import StrOutputParser
+from langchain_core.prompts import ChatPromptTemplate
+
+from .agents import build_chat_model
+
 
 RAG_PROMPT_TEMPLATE = """
 당신은 변호사를 보조하는 전문 법률 AI 어시스턴트입니다.
@@ -21,18 +21,19 @@ RAG_PROMPT_TEMPLATE = """
 [답변]
 """
 
+
 def get_rag_answer(query, context_chunks):
     """검색된 RAG 청크와 쿼리를 바탕으로 LLM 답변을 생성합니다."""
-    
+
     context_str = "\n\n---\n\n".join(
         f"출처: {chunk['source']}\n내용: {chunk['text']}" for chunk in context_chunks
     )
-    
+
     prompt = ChatPromptTemplate.from_template(RAG_PROMPT_TEMPLATE)
-    chain = prompt | llm | StrOutputParser()
-    
+    chain = prompt | build_chat_model() | StrOutputParser()
+
     response = chain.invoke({
         "context": context_str,
-        "query": query
+        "query": query,
     })
     return response, context_str

--- a/src/nodes.py
+++ b/src/nodes.py
@@ -1,254 +1,214 @@
-import random
-from typing import Any, Dict, Optional
+"""LangGraph nodes implementing the assistant pipeline."""
+from __future__ import annotations
 
-from src.state import TrialState
-import src.console as console
-from src.agents import (
-    redis_client,
-    JUDGE_PERSONALITY_POOL,
-    lawyer_chain,
-    judge_chain,
-    presiding_judge_chain,
-    evaluation_chain,
-    reflection_chain,
-    critic_chain,
-    CRITIQUE_CRITERIA
+import json
+from contextlib import closing
+from typing import List
+
+from langchain_core.messages import BaseMessage
+
+from .agents import (
+    draft_chain,
+    format_references_for_prompt,
+    rag_response_chain,
+    summarize_chain,
+    simulation_chain,
 )
-from src.vector_db import add_case_to_db, search_similar_cases
+from .db_utils import get_db_connection, set_rls_user
+from .file_processor import ingest_document
+from .state import AssistantState, RetrievedChunk
+from .vector_db import (
+    search_private_chunks,
+    search_public_precedents,
+    search_public_statutes,
+)
 
-def start_trial(state: TrialState):
-    """재판 시작: 초기 설정 및 서브 판사 3명 무작위 선택"""
-    console.print_header("모의 법정 시뮬레이션을 시작합니다")
-    state['max_turns'] = 4
-    state['turn_count'] = 0
-    state['debate_transcript'] = []
-    
-    selected_judges = random.sample(JUDGE_PERSONALITY_POOL, 3)
-    state['selected_judges'] = selected_judges
-    
-    console.print_judge_panel(selected_judges)
+
+def _unpack_response(response: BaseMessage | str) -> str:
+    if isinstance(response, str):
+        return response
+    if hasattr(response, "content"):
+        return str(response.content)
+    return str(response)
+
+
+def ingest_node(state: AssistantState) -> AssistantState:
+    """Parse the uploaded file and persist it to the database."""
+
+    required_fields = ["firm_id", "user_id", "file_name", "file_bytes"]
+    for field in required_fields:
+        if field not in state:
+            raise ValueError(f"ingest_node requires '{field}' in the state")
+
+    parsed, stored = ingest_document(
+        firm_id=state["firm_id"],
+        user_id=state["user_id"],
+        file_bytes=state["file_bytes"],
+        file_name=state["file_name"],
+        mime_type=state.get("mime_type"),
+        enable_ocr=state.get("enable_ocr", False),
+    )
+
+    state["raw_text"] = parsed.text
+    state["doc_id"] = stored.doc_id
+    state["revision_id"] = stored.revision_id
+    state["chunk_ids"] = stored.chunk_ids
+    state["pii_flag"] = stored.pii_flag
     return state
 
-def lawyer_debate_node(state: TrialState):
-    """변호사 토론: 유사 사건 검색 및 개인 DB를 바탕으로 변론"""
-    turn = state['turn_count'] + 1
-    console.print_turn_header(turn)
-    
-    transcript_str = "\n".join(
-        [f"{msg['agent_name']}: {msg['speech']}" for msg in state['debate_transcript']]
-    )
 
-    if state['turn_count'] % 2 == 0:
-        speaker_name = state['plaintiff_lawyer']
-        client_type = "원고"
-        db_key_prefix = "plaintiff_lawyer"
-    else:
-        speaker_name = state['defendant_lawyer']
-        client_type = "피고"
-        db_key_prefix = "defendant_lawyer"
-    
-    similar_cases_str = search_similar_cases(state['case_file'])
-    
-    successful_lessons = "\n".join(redis_client.lrange(f"{db_key_prefix}:successful_strategies", 0, -1))
-    failed_lessons = "\n".join(redis_client.lrange(f"{db_key_prefix}:failed_strategies", 0, -1))
-    past_lessons_str = f"성공 전략:\n{successful_lessons}\n\n실패 전략:\n{failed_lessons}"
-    
-    if not successful_lessons and not failed_lessons:
-        past_lessons_str = "아직 재판 경험이 없습니다."
-        
-    response_ai = lawyer_chain.invoke({
-        "client_type": client_type,
-        "case_file": state['case_file'],
-        "transcript": transcript_str,
-        "past_lessons": past_lessons_str,
-        "similar_cases": similar_cases_str
-    })
-    response = response_ai.content
-        
-    console.print_speech(speaker_name, response)
-    state['debate_transcript'].append({"agent_name": speaker_name, "speech": response})
-    state['turn_count'] += 1
-    return state
+def summarize_node(state: AssistantState) -> AssistantState:
+    """Produce an executive summary and extract legal issues."""
 
-def associate_judge_deliberation_node(state: TrialState):
-    """서브 판사 심의: 실제 LLM을 호출하여 페르소나 기반 판결"""
-    console.print_verdict_header("서브 판사 심의")
-    
-    transcript_str = "\n".join(
-        [f"{msg['agent_name']}: {msg['speech']}" for msg in state['debate_transcript']]
-    )
-    
-    verdicts = []
-    for i, judge_info in enumerate(state['selected_judges']):
-        judge_name = judge_info['name']
-        judge_description = judge_info['description']
-        
-        response_ai = judge_chain.invoke({
-            "judge_name": judge_name,
-            "judge_description": judge_description,
-            "transcript": transcript_str
-        })
-        verdict = response_ai.content
-        
-        console.print_speech(judge_name, verdict)
-        verdicts.append({"agent_name": judge_name, "speech": verdict})
-    
-    state['associate_judge_verdicts'] = verdicts
-    return state
+    document_text = state.get("raw_text")
+    if not document_text:
+        raise ValueError("summarize_node requires 'raw_text' in the state")
 
-def final_judgment_node(state: TrialState):
-    """최종 판결: 재판장 LLM이 모든 내용을 종합하여 판결문 생성"""
-    console.print_verdict_header("최종 판결 선고")
-    
-    transcript_str = "\n".join(
-        [f"{msg['agent_name']}: {msg['speech']}" for msg in state['debate_transcript']]
-    )
-    judge_verdicts_str = "\n\n".join(
-        [f"[{msg['agent_name']}의 의견]\n{msg['speech']}" for msg in state['associate_judge_verdicts']]
-    )
-    
-    response_ai = presiding_judge_chain.invoke({
-        "transcript": transcript_str,
-        "judge_verdicts": judge_verdicts_str
-    })
-    final_verdict = response_ai.content
-    
-    console.print_final_verdict(final_verdict)
-    state['final_verdict'] = final_verdict
-    return state
-
-def update_knowledge_base_node(state: TrialState):
-    """변호사 DB 업데이트 및 이번 사건을 벡터 DB에 저장"""
-    console.print_update_header()
-    
-    evaluation_response = evaluation_chain.invoke({"final_verdict": state['final_verdict']})
-    plaintiff_outcome = evaluation_response.content.strip()
-    state['plaintiff_outcome'] = plaintiff_outcome
-    console.console.print(f"분석 결과: 원고측 '{plaintiff_outcome}'\n")
-
-    outcomes = {
-        state['plaintiff_lawyer']: {"outcome": plaintiff_outcome, "db_key_prefix": "plaintiff_lawyer"},
-        state['defendant_lawyer']: {
-            "outcome": "승리" if plaintiff_outcome == "패배" else ("패배" if plaintiff_outcome == "승리" else "무승부"),
-            "db_key_prefix": "defendant_lawyer"
-        }
-    }
-
-    lessons = {}
-    for lawyer_name, info in outcomes.items():
-        outcome = info['outcome']
-        db_key_prefix = info['db_key_prefix']
-        
-        my_speeches = "\n".join(
-            [s['speech'] for s in state['debate_transcript'] if s['agent_name'] == lawyer_name]
-        )
-        
-        reflection_response = reflection_chain.invoke({"outcome": outcome, "my_speeches": my_speeches})
-        lesson = reflection_response.content.strip()
-        lessons[db_key_prefix] = lesson
-        
-        console.print_lesson(lawyer_name, outcome, lesson)
-
-        if outcome == "승리":
-            redis_client.rpush(f"{db_key_prefix}:successful_strategies", lesson)
-        elif outcome == "패배":
-            redis_client.rpush(f"{db_key_prefix}:failed_strategies", lesson)
-
-    add_case_to_db(
-        case_summary=state['case_file'],
-        verdict=state['final_verdict'],
-        plaintiff_lesson=lessons.get("plaintiff_lawyer", "N/A"),
-        defendant_lesson=lessons.get("defendant_lawyer", "N/A")
-    )
-    
-    return state
-
-def critique_node(state: TrialState):
-    """비평가 에이전트가 최종 판결을 평가하고 점수를 State에 기록합니다."""
-    console.print_verdict_header("판결 품질 평가 (벤치마크 점수)")
-
-    transcript_str = "\n".join(
-        [f"{msg['agent_name']}: {msg['speech']}" for msg in state['debate_transcript']]
-    )
-
-    default_scores: Dict[str, Dict[str, Any]] = {
-        criteria: {
-            "criteria": criteria,
-            "score": 0,
-            "reason": "평가가 생성되지 않았습니다.",
-        }
-        for criteria in CRITIQUE_CRITERIA
-    }
-    failure_reason: Optional[str] = None
-    structured_dump: Optional[Dict[str, Any]] = None
+    response = summarize_chain.invoke({"document_text": document_text})
+    payload = _unpack_response(response)
 
     try:
-        critique_response = critic_chain.invoke({
-            "transcript": transcript_str,
-            "final_verdict": state['final_verdict']
-        })
+        data = json.loads(payload)
+    except json.JSONDecodeError:
+        issues: List[str] = [line.strip("-• ") for line in payload.splitlines() if line.strip()]
+        state["summary"] = issues[0] if issues else payload
+        state["issues"] = issues[1:] if len(issues) > 1 else issues
+        return state
 
-        if hasattr(critique_response, "model_dump"):
-            structured_dump = critique_response.model_dump()  # type: ignore[assignment]
-            evaluations = structured_dump.get("evaluations", [])
-        elif isinstance(critique_response, dict):
-            structured_dump = critique_response
-            evaluations = structured_dump.get("evaluations", [])
-        else:
-            evaluations = getattr(critique_response, "evaluations", [])
+    state["summary"] = data.get("summary", "")
+    raw_issues = data.get("issues", [])
+    if isinstance(raw_issues, list):
+        state["issues"] = [str(item) for item in raw_issues]
+    elif isinstance(raw_issues, str):
+        state["issues"] = [part.strip() for part in raw_issues.split("\n") if part.strip()]
+    else:
+        state["issues"] = []
+    return state
 
-        if evaluations is None:
-            evaluations = []
 
-        for item in evaluations:
-            if hasattr(item, "model_dump"):
-                item_data = item.model_dump()  # type: ignore[assignment]
-            elif isinstance(item, dict):
-                item_data = item
-            else:
-                item_data = {
-                    "criteria": getattr(item, "criteria", None),
-                    "score": getattr(item, "score", 0),
-                    "reason": getattr(item, "reason", ""),
-                }
+def rag_chain_node(state: AssistantState) -> AssistantState:
+    """Retrieve private and public precedents for the matter."""
 
-            criteria = item_data.get("criteria")
-            if criteria not in default_scores:
-                continue
+    summary = state.get("summary")
+    issues = state.get("issues", [])
+    if not summary:
+        raise ValueError("rag_chain_node requires 'summary' in the state")
 
-            try:
-                score_value = int(item_data.get("score", 0))
-            except (TypeError, ValueError):
-                score_value = 0
+    query = f"{summary}\n\n" + "\n".join(issues)
+    references: List[RetrievedChunk] = []
 
-            reason_text = (item_data.get("reason") or "").strip() or "평가 이유가 제공되지 않았습니다."
-            default_scores[criteria] = {
-                "criteria": criteria,
-                "score": 1 if score_value == 1 else 0,
-                "reason": reason_text,
+    with closing(get_db_connection()) as conn:
+        set_rls_user(conn, state["firm_id"])
+        references.extend(search_private_chunks(conn, query, top_k=5))
+        references.extend(search_public_statutes(conn, query, top_k=3))
+        references.extend(search_public_precedents(conn, query, top_k=3))
+
+    state["rag_results"] = references
+
+    reference_strings = tuple(f"{item['source']} => {item['text']}" for item in references)
+    if reference_strings:
+        response = rag_response_chain.invoke(
+            {
+                "summary": summary,
+                "issues": "\n".join(issues),
+                "references": format_references_for_prompt(reference_strings),
             }
-
-        if structured_dump is not None and len(structured_dump.get("evaluations", [])) < len(CRITIQUE_CRITERIA):
-            console.console.print("\n[bold yellow]일부 평가 항목이 누락되었습니다. 원본 응답을 검토하세요:[/bold yellow]")
-            console.console.print(structured_dump)
-
-    except Exception as error:
-        failure_reason = str(error)
-        console.console.print(f"\n[bold yellow]품질 평가 생성 중 오류:[/bold yellow] {failure_reason}")
-
-    for criteria, info in default_scores.items():
-        if info["reason"] == "평가가 생성되지 않았습니다.":
-            if failure_reason:
-                info["reason"] = f"평가 실패: {failure_reason}"
+        )
+        payload = _unpack_response(response)
+        try:
+            data = json.loads(payload)
+            analysis_items = data.get("analysis", [])
+            if isinstance(analysis_items, list):
+                formatted = []
+                for item in analysis_items:
+                    source = item.get("source", "출처 미상") if isinstance(item, dict) else str(item)
+                    reasoning = item.get("reasoning", "") if isinstance(item, dict) else ""
+                    formatted.append(f"{source}: {reasoning}".strip())
+                state["reference_analysis"] = "\n".join(formatted)
             else:
-                info["reason"] = "LLM이 해당 기준에 대한 평가를 제공하지 않았습니다."
+                state["reference_analysis"] = payload
+        except json.JSONDecodeError:
+            state["reference_analysis"] = payload
+    else:
+        state["reference_analysis"] = "관련 근거를 찾지 못했습니다."
 
-    console.console.print("\n[bold]판결 품질 벤치마크:[/bold]")
-    for item in default_scores.values():
-        result = "[bold green]PASS[/bold green]" if item["score"] == 1 else "[bold red]FAIL[/bold red]"
-        console.console.print(f"- [bold]{item['criteria']}[/bold]: {result}")
-        console.console.print(f"  (평가 이유: {item['reason']})")
+    return state
 
-    state['critique_scores'] = list(default_scores.values())
 
+def drafting_node(state: AssistantState) -> AssistantState:
+    """Generate a first draft using retrieved authorities."""
+
+    summary = state.get("summary", "")
+    issues = state.get("issues", [])
+    reference_analysis = state.get("reference_analysis", "")
+
+    response = draft_chain.invoke(
+        {
+            "summary": summary,
+            "issues": "\n".join(issues),
+            "reference_analysis": reference_analysis,
+        }
+    )
+    state["draft_text"] = _unpack_response(response)
+    return state
+
+
+def simulation_node(state: AssistantState) -> AssistantState:
+    """Simulate counter arguments and risky precedents."""
+
+    draft_text = state.get("draft_text")
+    if not draft_text:
+        raise ValueError("simulation_node requires 'draft_text' in the state")
+
+    response = simulation_chain.invoke({"draft_text": draft_text})
+    payload = _unpack_response(response)
+    try:
+        data = json.loads(payload)
+        counter = data.get("counter_arguments", [])
+        precedents = data.get("risky_precedents", [])
+        lines = ["예상 반론:"]
+        lines.extend(f"- {item}" for item in counter)
+        lines.append("\n불리할 수 있는 판례:")
+        lines.extend(f"- {item}" for item in precedents)
+        state["simulation_report"] = "\n".join(lines)
+    except json.JSONDecodeError:
+        state["simulation_report"] = payload
+    return state
+
+
+def feedback_node(state: AssistantState) -> AssistantState:
+    """Persist user feedback to the feedback table if provided."""
+
+    feedback = state.get("user_feedback")
+    if not feedback:
+        state["feedback_saved"] = False
+        return state
+
+    doc_id = state.get("doc_id")
+    if not doc_id:
+        raise ValueError("feedback_node requires 'doc_id' when user_feedback is provided")
+
+    with closing(get_db_connection()) as conn:
+        set_rls_user(conn, state["firm_id"])
+        chunk_id = state.get("chunk_ids", [None])[0]
+        label = state.get("feedback_label", "revise")
+        reason = state.get("feedback_reason")
+        with conn.cursor() as cur:
+            cur.execute(
+                """
+                INSERT INTO feedback (firm_id, user_id, doc_id, chunk_id, reason, revised_text, label)
+                VALUES (%s, %s, %s, %s, %s, %s, %s)
+                """,
+                (
+                    state["firm_id"],
+                    state["user_id"],
+                    doc_id,
+                    chunk_id,
+                    reason,
+                    feedback,
+                    label,
+                ),
+            )
+        conn.commit()
+    state["feedback_saved"] = True
     return state

--- a/src/state.py
+++ b/src/state.py
@@ -1,20 +1,48 @@
-from typing import List, TypedDict, Optional
+"""Application state definitions for the B2B legal assistant."""
+from __future__ import annotations
 
-class AgentSpeech(TypedDict):
-    """에이전트의 발언을 저장하는 형식"""
-    agent_name: str
-    speech: str
+from typing import List, Optional, TypedDict
 
-class TrialState(TypedDict):
-    """재판 전체의 상태를 관리하는 형식"""
-    case_file: str
-    plaintiff_lawyer: str
-    defendant_lawyer: str
-    selected_judges: List[dict]
-    debate_transcript: List[AgentSpeech]
-    turn_count: int
-    max_turns: int
-    associate_judge_verdicts: List[AgentSpeech]
-    final_verdict: Optional[str]
-    plaintiff_outcome: Optional[str]
-    critique_scores: Optional[list]  # 👈 벤치마크 점수를 저장할 필드
+
+class RetrievedChunk(TypedDict, total=False):
+    """Representation of a retrieved text chunk that can be surfaced to the LLM."""
+
+    text: str
+    source: str
+    chunk_id: Optional[int]
+
+
+class AssistantState(TypedDict, total=False):
+    """Workflow state shared between LangGraph nodes."""
+
+    # Session context
+    firm_id: int
+    user_id: int
+    file_name: str
+    mime_type: Optional[str]
+    file_bytes: bytes
+    enable_ocr: bool
+
+    # Ingestion output
+    raw_text: str
+    doc_id: Optional[int]
+    revision_id: Optional[int]
+    chunk_ids: List[int]
+    pii_flag: bool
+
+    # Analytical artefacts
+    summary: str
+    issues: List[str]
+    rag_results: List[RetrievedChunk]
+    reference_analysis: str
+    draft_text: str
+    simulation_report: str
+
+    # Optional feedback payload coming from the UI layer
+    user_feedback: Optional[str]
+    feedback_reason: Optional[str]
+    feedback_label: Optional[str]
+    feedback_saved: bool
+
+    # Export hooks
+    export_path: Optional[str]

--- a/src/vector_db.py
+++ b/src/vector_db.py
@@ -1,22 +1,34 @@
-# 파일명: src/vector_db.py (대대적 수정)
-from langchain_community.embeddings import SentenceTransformerEmbeddings
-from .file_processor import EMBEDDING_MODEL, EMBEDDING_DIM
+"""Vector search helpers wrapping pgvector queries."""
+from __future__ import annotations
 
-# 임베딩 모델 인스턴스 (file_processor와 동일해야 함)
+from typing import List
+
+from langchain_community.embeddings import SentenceTransformerEmbeddings
+
+from .file_processor import EMBEDDING_DIM, EMBEDDING_MODEL
+
 embeddings = SentenceTransformerEmbeddings(model_name=EMBEDDING_MODEL)
 
-def search_private_chunks(conn, query, top_k=3):
-    """
-    현재 세션(firm_id)의 '전용 DB'에서 문서 청크를 검색합니다.
-    RLS가 적용되므로 firm_id를 명시적으로 WHERE절에 넣을 필요가 없습니다.
-    """
+
+def _format_results(rows, source_prefix: str) -> List[dict]:
+    formatted = []
+    for text, source_label, identifier in rows:
+        formatted.append(
+            {
+                "text": text,
+                "source": f"{source_prefix}: {source_label}",
+                "chunk_id": identifier,
+            }
+        )
+    return formatted
+
+
+def search_private_chunks(conn, query: str, top_k: int = 3) -> List[dict]:
     query_vector = embeddings.embed_query(query)
-    
     with conn.cursor() as cur:
-        # RLS가 활성화된 doc_chunk_embedding 테이블을 쿼리합니다.
         cur.execute(
             f"""
-            SELECT c.text, d.title
+            SELECT c.text, d.title, c.chunk_id
             FROM doc_chunk_embedding e
             JOIN doc_chunk c ON e.chunk_id = c.chunk_id
             JOIN document d ON c.doc_id = d.doc_id
@@ -24,19 +36,18 @@ def search_private_chunks(conn, query, top_k=3):
             ORDER BY e.embedding <=> %s::VECTOR({EMBEDDING_DIM})
             LIMIT %s
             """,
-            (EMBEDDING_MODEL, query_vector, top_k)
+            (EMBEDDING_MODEL, query_vector, top_k),
         )
-        results = cur.fetchall()
-        return [{"text": row[0], "source": f"전용문서: {row[1]}"} for row in results]
+        rows = cur.fetchall()
+    return _format_results(rows, "전용문서")
 
-def search_public_statutes(conn, query, top_k=2):
-    """'공용 법령 DB'에서 관련 조항을 검색합니다."""
+
+def search_public_statutes(conn, query: str, top_k: int = 2) -> List[dict]:
     query_vector = embeddings.embed_query(query)
-    
     with conn.cursor() as cur:
         cur.execute(
             f"""
-            SELECT sa.text, s.title_ko, sa.number
+            SELECT sa.text, CONCAT(s.title_ko, ' ', COALESCE(sa.number, '')), sa.article_id
             FROM statute_article_embedding e
             JOIN statute_article sa ON e.article_id = sa.article_id
             JOIN statute s ON sa.statute_id = s.statute_id
@@ -44,10 +55,26 @@ def search_public_statutes(conn, query, top_k=2):
             ORDER BY e.embedding <=> %s::VECTOR({EMBEDDING_DIM})
             LIMIT %s
             """,
-            (EMBEDDING_MODEL, query_vector, top_k)
+            (EMBEDDING_MODEL, query_vector, top_k),
         )
-        results = cur.fetchall()
-        return [{"text": row[0], "source": f"법령: {row[1]} {row[2]}"} for row in results]
+        rows = cur.fetchall()
+    return _format_results(rows, "법령")
 
-# TODO: search_public_precedents (판례 검색) 함수도 위와 유사하게 구현
-# (init.sql의 precedent_section_embedding 테이블을 쿼리)
+
+def search_public_precedents(conn, query: str, top_k: int = 2) -> List[dict]:
+    query_vector = embeddings.embed_query(query)
+    with conn.cursor() as cur:
+        cur.execute(
+            f"""
+            SELECT ps.text, CONCAT(p.court, ' ', COALESCE(p.case_no, '')), ps.section_id
+            FROM precedent_section_embedding e
+            JOIN precedent_section ps ON e.section_id = ps.section_id
+            JOIN precedent p ON ps.case_id = p.case_id
+            WHERE e.model_name = %s
+            ORDER BY e.embedding <=> %s::VECTOR({EMBEDDING_DIM})
+            LIMIT %s
+            """,
+            (EMBEDDING_MODEL, query_vector, top_k),
+        )
+        rows = cur.fetchall()
+    return _format_results(rows, "판례")


### PR DESCRIPTION
## Summary
- replace the previous mock court workflow with a document-centric legal assistant graph that ingests files, summarises issues, retrieves RAG context, drafts briefs, and simulates counter arguments
- add configurable local-LLM friendly prompt chains and parsing utilities plus revamped file ingestion with chunk storage, embeddings, and feedback handling
- extend database helpers, CLI tooling, and demos to support statute/precedent loading, benchmarking, and Streamlit ingestion aligned with the new schema and RLS policies

## Testing
- python -m compileall .

------
https://chatgpt.com/codex/tasks/task_e_68f6f04e0428832496300cabdc3f87c6