### PR TITLE
Add combined workflow orchestration endpoint

### DIFF
--- a/init.sql
+++ b/init.sql
@@ -185,13 +185,16 @@ CREATE TABLE IF NOT EXISTS user_style_hint (
 -- 처리 이력
 CREATE TABLE IF NOT EXISTS processing_job (
   job_id         BIGSERIAL PRIMARY KEY,
+  firm_id        BIGINT REFERENCES firm(firm_id) NOT NULL,
   doc_id         BIGINT REFERENCES document(doc_id),
-  step           TEXT CHECK (step IN ('upload','parse','ocr','chunk','embed','done')),
+  step           TEXT CHECK (step IN ('upload','parse','ocr','chunk','embed','draft','workflow','done')),
   status         TEXT CHECK (status IN ('queued','running','succeeded','failed')) DEFAULT 'queued',
   detail         JSONB,
   created_at     TIMESTAMPTZ DEFAULT now(),
   updated_at     TIMESTAMPTZ DEFAULT now()
 );
+
+CREATE INDEX IF NOT EXISTS idx_processing_job_firm_step ON processing_job(firm_id, step);
 
 CREATE TABLE IF NOT EXISTS ocr_run (
   ocr_id         BIGSERIAL PRIMARY KEY,
@@ -208,6 +211,7 @@ ALTER TABLE document ENABLE ROW LEVEL SECURITY;
 ALTER TABLE doc_chunk ENABLE ROW LEVEL SECURITY;
 ALTER TABLE private_case_meta ENABLE ROW LEVEL SECURITY;
 ALTER TABLE feedback ENABLE ROW LEVEL SECURITY;
+ALTER TABLE processing_job ENABLE ROW LEVEL SECURITY;
 
 DROP POLICY IF EXISTS doc_firm_isolation ON document;
 CREATE POLICY doc_firm_isolation ON document
@@ -226,6 +230,10 @@ CREATE POLICY private_meta_firm_isolation ON private_case_meta
 
 DROP POLICY IF EXISTS fb_firm_isolation ON feedback;
 CREATE POLICY fb_firm_isolation ON feedback
+  USING (firm_id = current_setting('app.firm_id', true)::BIGINT);
+
+DROP POLICY IF EXISTS job_firm_isolation ON processing_job;
+CREATE POLICY job_firm_isolation ON processing_job
   USING (firm_id = current_setting('app.firm_id', true)::BIGINT);
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,6 +9,9 @@ psycopg2-binary
 langchain-postgres
 python-dotenv
 langchain-smith
+fastapi
+uvicorn
+python-multipart
 
 # --- 데모용 추가 라이브러리 ---
 streamlit

--- a/src/api.py
+++ b/src/api.py
@@ -1,0 +1,341 @@
+"""FastAPI router exposing the MVP workflow endpoints."""
+from __future__ import annotations
+
+import io
+from contextlib import closing
+from typing import Optional
+
+from fastapi import Depends, FastAPI, File, Form, HTTPException, Request, UploadFile
+from fastapi.responses import JSONResponse, StreamingResponse
+from pydantic import BaseModel
+
+from .db_utils import ProcessingJobLogger, get_db_connection, set_rls_user
+from .file_processor import ingest_document
+from .workflows import (
+    fetch_document_chunks,
+    fetch_document_overview,
+    fetch_embedding_overview,
+    ingest_and_run_pipeline,
+    run_pipeline_for_document,
+)
+
+try:  # Optional dependency used in /export/docx
+    import docx  # type: ignore
+except ImportError:  # pragma: no cover - optional dependency guard
+    docx = None
+
+
+class RequestContext(BaseModel):
+    firm_id: int
+    user_id: int
+
+
+async def get_request_context(request: Request) -> RequestContext:
+    """Extract firm/user identifiers from request headers."""
+
+    firm_header = request.headers.get("X-Firm-Id")
+    user_header = request.headers.get("X-User-Id")
+    if firm_header is None or user_header is None:
+        raise HTTPException(status_code=401, detail="요청 헤더에 X-Firm-Id / X-User-Id 가 필요합니다.")
+    try:
+        firm_id = int(firm_header)
+        user_id = int(user_header)
+    except ValueError as exc:  # pragma: no cover - defensive guard
+        raise HTTPException(status_code=401, detail="헤더 값이 올바른 정수가 아닙니다.") from exc
+    return RequestContext(firm_id=firm_id, user_id=user_id)
+
+
+app = FastAPI(title="Court Agent API", version="0.1.0")
+
+
+def _open_connection(context: RequestContext):
+    conn = get_db_connection()
+    set_rls_user(conn, context.firm_id)
+    return conn
+@app.post("/upload")
+async def upload_document(
+    context: RequestContext = Depends(get_request_context),
+    file: UploadFile = File(...),
+    enable_ocr: bool = Form(False),
+):
+    file_bytes = await file.read()
+    if not file_bytes:
+        raise HTTPException(status_code=400, detail="업로드된 파일이 비어 있습니다.")
+
+    conn = _open_connection(context)
+    tracker = ProcessingJobLogger(conn, context.firm_id, context.user_id)
+    upload_job_id = tracker.start_step(
+        "upload",
+        detail={
+            "file_name": file.filename,
+            "mime_type": file.content_type,
+            "size": len(file_bytes),
+        },
+    )
+
+    try:
+        parsed, stored = ingest_document(
+            context.firm_id,
+            context.user_id,
+            file_bytes,
+            file.filename or "uploaded",  # pragma: no cover - UploadFile always has name
+            mime_type=file.content_type,
+            enable_ocr=enable_ocr,
+            conn=conn,
+            tracker=tracker,
+        )
+        tracker.succeed_step(
+            upload_job_id,
+            detail={"bytes": len(file_bytes)},
+            doc_id=stored.doc_id,
+        )
+        jobs = tracker.list_jobs_for_doc(stored.doc_id)
+        return {
+            "doc_id": stored.doc_id,
+            "revision_id": stored.revision_id,
+            "chunk_count": len(stored.chunk_ids),
+            "pii_flag": stored.pii_flag,
+            "jobs": jobs,
+        }
+    except ValueError as exc:
+        tracker.fail_step(upload_job_id, detail={"error": str(exc)})
+        tracker.cancel_pending()
+        raise HTTPException(status_code=400, detail=str(exc))
+    except NotImplementedError as exc:
+        tracker.fail_step(upload_job_id, detail={"error": str(exc)})
+        tracker.cancel_pending()
+        raise HTTPException(status_code=501, detail=str(exc))
+    except Exception as exc:  # pragma: no cover - defensive guard
+        tracker.fail_step(upload_job_id, detail={"error": str(exc)})
+        tracker.cancel_pending()
+        raise HTTPException(status_code=500, detail="문서를 처리하는 중 오류가 발생했습니다.") from exc
+    finally:
+        conn.close()
+
+
+@app.post("/workflow")
+async def upload_and_generate_workflow(
+    context: RequestContext = Depends(get_request_context),
+    file: UploadFile = File(...),
+    enable_ocr: bool = Form(False),
+    include_simulation: bool = Form(True),
+):
+    file_bytes = await file.read()
+    if not file_bytes:
+        raise HTTPException(status_code=400, detail="업로드된 파일이 비어 있습니다.")
+
+    conn = _open_connection(context)
+    tracker = ProcessingJobLogger(conn, context.firm_id, context.user_id)
+    upload_job_id = tracker.start_step(
+        "upload",
+        detail={
+            "file_name": file.filename,
+            "mime_type": file.content_type,
+            "size": len(file_bytes),
+        },
+    )
+
+    try:
+        result = ingest_and_run_pipeline(
+            conn,
+            firm_id=context.firm_id,
+            user_id=context.user_id,
+            file_bytes=file_bytes,
+            file_name=file.filename or "uploaded",
+            mime_type=file.content_type,
+            enable_ocr=enable_ocr,
+            include_simulation=include_simulation,
+            tracker=tracker,
+        )
+    except ValueError as exc:
+        tracker.fail_step(upload_job_id, detail={"error": str(exc)})
+        tracker.cancel_pending()
+        raise HTTPException(status_code=400, detail=str(exc)) from None
+    except NotImplementedError as exc:
+        tracker.fail_step(upload_job_id, detail={"error": str(exc)})
+        tracker.cancel_pending()
+        raise HTTPException(status_code=501, detail=str(exc))
+    except Exception as exc:  # pragma: no cover - defensive guard
+        tracker.fail_step(upload_job_id, detail={"error": str(exc)})
+        tracker.cancel_pending()
+        raise HTTPException(status_code=500, detail="문서를 처리하는 중 오류가 발생했습니다.") from exc
+    else:
+        stored = result["stored"]
+        tracker.succeed_step(
+            upload_job_id,
+            detail={"bytes": len(file_bytes)},
+            doc_id=stored.doc_id,
+        )
+        jobs = tracker.list_jobs_for_doc(stored.doc_id)
+        state = result["state"]
+        overview = result["overview"]
+        return {
+            "doc_id": overview["doc_id"],
+            "revision_id": stored.revision_id,
+            "title": overview["title"],
+            "page_count": overview["page_count"],
+            "pii_flag": overview["pii_flag"],
+            "summary": state.get("summary"),
+            "issues": state.get("issues", []),
+            "rag_results": state.get("rag_results", []),
+            "draft_text": state.get("draft_text"),
+            "simulation_report": state.get("simulation_report"),
+            "jobs": jobs,
+            "workflow_job_id": result["workflow_job_id"],
+            "draft_job_id": result["draft_job_id"],
+        }
+    finally:
+        conn.close()
+
+
+@app.get("/parse/{doc_id}")
+def get_parse_result(doc_id: int, context: RequestContext = Depends(get_request_context)):
+    with closing(_open_connection(context)) as conn:
+        try:
+            overview = fetch_document_overview(conn, doc_id)
+        except LookupError:
+            raise HTTPException(status_code=404, detail="문서를 찾을 수 없습니다.")
+        chunks = fetch_document_chunks(conn, doc_id)
+    return {
+        "doc_id": overview["doc_id"],
+        "title": overview["title"],
+        "page_count": overview["page_count"],
+        "pii_flag": overview["pii_flag"],
+        "chunk_count": len(chunks),
+        "chunks": [
+            {
+                "chunk_id": chunk["chunk_id"],
+                "position": chunk["position"],
+                "preview": chunk["text"][:200],
+            }
+            for chunk in chunks
+        ],
+    }
+
+
+@app.get("/embed/{doc_id}")
+def get_embedding_status(doc_id: int, context: RequestContext = Depends(get_request_context)):
+    with closing(_open_connection(context)) as conn:
+        try:
+            overview = fetch_document_overview(conn, doc_id)
+        except LookupError:
+            raise HTTPException(status_code=404, detail="문서를 찾을 수 없습니다.")
+        embeddings = fetch_embedding_overview(conn, doc_id)
+    return {
+        "doc_id": overview["doc_id"],
+        "title": overview["title"],
+        "pii_flag": overview["pii_flag"],
+        "embeddings": embeddings,
+    }
+
+
+class DraftRequest(BaseModel):
+    doc_id: int
+    include_simulation: bool = True
+
+
+@app.post("/draft")
+def generate_draft(payload: DraftRequest, context: RequestContext = Depends(get_request_context)):
+    with closing(_open_connection(context)) as conn:
+        tracker = ProcessingJobLogger(conn, context.firm_id, context.user_id)
+        try:
+            state, overview, chunks, draft_job_id = run_pipeline_for_document(
+                conn,
+                payload.doc_id,
+                context.firm_id,
+                context.user_id,
+                include_simulation=payload.include_simulation,
+                tracker=tracker,
+            )
+        except LookupError:
+            tracker.cancel_pending()
+            raise HTTPException(status_code=404, detail="문서를 찾을 수 없습니다.")
+        except ValueError as exc:
+            tracker.cancel_pending()
+            raise HTTPException(status_code=400, detail=str(exc))
+        except Exception as exc:  # pragma: no cover - defensive guard
+            tracker.cancel_pending()
+            raise HTTPException(status_code=500, detail="문서 초안을 생성하는 중 오류가 발생했습니다.") from exc
+
+        jobs = tracker.list_jobs_for_doc(payload.doc_id)
+
+    return {
+        "doc_id": overview["doc_id"],
+        "title": overview["title"],
+        "summary": state.get("summary"),
+        "issues": state.get("issues", []),
+        "rag_results": state.get("rag_results", []),
+        "draft_text": state.get("draft_text"),
+        "simulation_report": state.get("simulation_report"),
+        "draft_job_id": draft_job_id,
+        "jobs": jobs,
+    }
+
+
+class FeedbackRequest(BaseModel):
+    doc_id: int
+    feedback: str
+    label: str = "revise"
+    reason: Optional[str] = None
+    chunk_id: Optional[int] = None
+
+
+@app.post("/feedback")
+def submit_feedback(payload: FeedbackRequest, context: RequestContext = Depends(get_request_context)):
+    with closing(_open_connection(context)) as conn:
+        with conn.cursor() as cur:
+            cur.execute(
+                """
+                INSERT INTO feedback (firm_id, user_id, doc_id, chunk_id, reason, revised_text, label)
+                VALUES (%s, %s, %s, %s, %s, %s, %s)
+                RETURNING fb_id
+                """,
+                (
+                    context.firm_id,
+                    context.user_id,
+                    payload.doc_id,
+                    payload.chunk_id,
+                    payload.reason,
+                    payload.feedback,
+                    payload.label,
+                ),
+            )
+            fb_id = cur.fetchone()[0]
+        conn.commit()
+    return JSONResponse(status_code=201, content={"feedback_id": fb_id})
+
+
+class ExportDocxRequest(BaseModel):
+    draft_text: str
+    file_name: Optional[str] = None
+
+
+@app.post("/export/docx")
+def export_docx(payload: ExportDocxRequest, context: RequestContext = Depends(get_request_context)):
+    if docx is None:  # pragma: no cover - optional dependency guard
+        raise HTTPException(status_code=500, detail="python-docx 패키지가 설치되어 있지 않습니다.")
+
+    document = docx.Document()
+    for paragraph in payload.draft_text.splitlines():
+        document.add_paragraph(paragraph)
+
+    buffer = io.BytesIO()
+    document.save(buffer)
+    buffer.seek(0)
+    filename = payload.file_name or "draft.docx"
+    return StreamingResponse(
+        buffer,
+        media_type="application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+        headers={"Content-Disposition": f"attachment; filename=\"{filename}\""},
+    )
+
+
+@app.get("/jobs/{job_id}")
+def get_job(job_id: int, context: RequestContext = Depends(get_request_context)):
+    with closing(_open_connection(context)) as conn:
+        logger = ProcessingJobLogger(conn, context.firm_id, context.user_id)
+        job = logger.fetch_job(job_id)
+    if not job:
+        raise HTTPException(status_code=404, detail="작업을 찾을 수 없습니다.")
+    return job
+

--- a/src/db_utils.py
+++ b/src/db_utils.py
@@ -1,25 +1,197 @@
-# 파일명: src/db_utils.py (신규)
-import psycopg2
+"""Database helpers and ingestion job logging utilities."""
+from __future__ import annotations
+
+import json
 import os
+from typing import Any, Dict, List, Optional
+
+import psycopg2
+
 
 def get_db_connection():
-    """DB 연결을 생성합니다."""
-    # .env 파일에서 DB 정보를 읽어옵니다. (기존 .env.example 참고)
-    conn = psycopg2.connect(
+    """Create a new PostgreSQL connection using environment variables."""
+
+    return psycopg2.connect(
         host=os.getenv("POSTGRES_HOST", "localhost"),
         database=os.getenv("POSTGRES_DB", "legal_db"),
         user=os.getenv("POSTGRES_USER", "user"),
         password=os.getenv("POSTGRES_PASSWORD", "password"),
-        port=os.getenv("POSTGRES_PORT", 5432)
+        port=os.getenv("POSTGRES_PORT", 5432),
     )
-    return conn
 
-def set_rls_user(conn, firm_id):
-    """
-    현재 DB 세션에 RLS를 위한 firm_id를 설정합니다.
-    이것이 B2B 보안의 핵심입니다.
-    """
+
+def set_rls_user(conn, firm_id: int) -> None:
+    """Ensure the session is tagged with the firm_id for RLS policies."""
+
     with conn.cursor() as cur:
-        # init.sql의 current_setting('app.firm_id', true)::BIGINT 와 일치해야 함
         cur.execute("SELECT set_config('app.firm_id', %s, false)", (str(firm_id),))
     conn.commit()
+
+
+class ProcessingJobLogger:
+    """Convenience wrapper around the processing_job table."""
+
+    def __init__(self, conn, firm_id: int, user_id: Optional[int] = None) -> None:
+        self.conn = conn
+        self.firm_id = firm_id
+        self.user_id = user_id
+        self._started_jobs: List[int] = []
+
+    # ------------------------------------------------------------------
+    def _serialise_detail(self, detail: Optional[Dict[str, Any]]) -> Optional[str]:
+        payload: Dict[str, Any] = {}
+        if self.user_id is not None:
+            payload["requested_by"] = self.user_id
+        if detail:
+            payload.update(detail)
+        return json.dumps(payload) if payload else None
+
+    def _update_job(
+        self,
+        job_id: int,
+        status: str,
+        *,
+        detail: Optional[Dict[str, Any]] = None,
+        doc_id: Optional[int] = None,
+    ) -> None:
+        with self.conn.cursor() as cur:
+            params: List[Any] = [status]
+            query = [
+                "UPDATE processing_job",
+                "   SET status = %s,",
+                "       updated_at = now()",
+            ]
+            if detail is not None:
+                query.append(",       detail = %s")
+                params.append(self._serialise_detail(detail))
+            if doc_id is not None:
+                query.append(",       doc_id = %s")
+                params.append(doc_id)
+            query.append(" WHERE job_id = %s")
+            params.append(job_id)
+            cur.execute("\n".join(query), tuple(params))
+        self.conn.commit()
+
+    # ------------------------------------------------------------------
+    def start_step(
+        self,
+        step: str,
+        *,
+        doc_id: Optional[int] = None,
+        status: str = "running",
+        detail: Optional[Dict[str, Any]] = None,
+    ) -> int:
+        with self.conn.cursor() as cur:
+            cur.execute(
+                """
+                INSERT INTO processing_job (firm_id, doc_id, step, status, detail)
+                VALUES (%s, %s, %s, %s, %s)
+                RETURNING job_id
+                """,
+                (
+                    self.firm_id,
+                    doc_id,
+                    step,
+                    status,
+                    self._serialise_detail(detail),
+                ),
+            )
+            job_id = cur.fetchone()[0]
+        self.conn.commit()
+        self._started_jobs.append(job_id)
+        return job_id
+
+    def succeed_step(
+        self,
+        job_id: int,
+        *,
+        detail: Optional[Dict[str, Any]] = None,
+        doc_id: Optional[int] = None,
+    ) -> None:
+        self._update_job(job_id, "succeeded", detail=detail, doc_id=doc_id)
+        if job_id in self._started_jobs:
+            self._started_jobs.remove(job_id)
+
+    def fail_step(
+        self,
+        job_id: int,
+        *,
+        detail: Optional[Dict[str, Any]] = None,
+    ) -> None:
+        self._update_job(job_id, "failed", detail=detail)
+        if job_id in self._started_jobs:
+            self._started_jobs.remove(job_id)
+
+    def list_jobs_for_doc(self, doc_id: int) -> List[Dict[str, Any]]:
+        with self.conn.cursor() as cur:
+            cur.execute(
+                """
+                SELECT job_id, step, status, detail, created_at, updated_at
+                  FROM processing_job
+                 WHERE doc_id = %s
+                 ORDER BY created_at
+                """,
+                (doc_id,),
+            )
+            rows = cur.fetchall()
+
+        jobs: List[Dict[str, Any]] = []
+        for row in rows:
+            detail = row[3]
+            if isinstance(detail, str):
+                try:
+                    detail_payload = json.loads(detail)
+                except json.JSONDecodeError:
+                    detail_payload = detail
+            else:
+                detail_payload = detail
+            jobs.append(
+                {
+                    "job_id": row[0],
+                    "step": row[1],
+                    "status": row[2],
+                    "detail": detail_payload,
+                    "created_at": row[4].isoformat() if row[4] else None,
+                    "updated_at": row[5].isoformat() if row[5] else None,
+                }
+            )
+        return jobs
+
+    def fetch_job(self, job_id: int) -> Optional[Dict[str, Any]]:
+        with self.conn.cursor() as cur:
+            cur.execute(
+                """
+                SELECT job_id, doc_id, step, status, detail, created_at, updated_at
+                  FROM processing_job
+                 WHERE job_id = %s
+                """,
+                (job_id,),
+            )
+            row = cur.fetchone()
+
+        if not row:
+            return None
+
+        detail = row[4]
+        if isinstance(detail, str):
+            try:
+                detail = json.loads(detail)
+            except json.JSONDecodeError:
+                pass
+        return {
+            "job_id": row[0],
+            "doc_id": row[1],
+            "step": row[2],
+            "status": row[3],
+            "detail": detail,
+            "created_at": row[5].isoformat() if row[5] else None,
+            "updated_at": row[6].isoformat() if row[6] else None,
+        }
+
+    def cancel_pending(self) -> None:
+        """Mark every started job as failed to avoid ghost entries."""
+
+        for job_id in list(self._started_jobs):
+            self.fail_step(job_id, detail={"error": "작업이 중단되었습니다."})
+        self._started_jobs.clear()
+

--- a/src/file_processor.py
+++ b/src/file_processor.py
@@ -24,7 +24,7 @@ try:  # Optional dependency for HWP parsing
 except ImportError:  # pragma: no cover - optional dependency guard
     pyhwp = None
 
-from .db_utils import get_db_connection, set_rls_user
+from .db_utils import ProcessingJobLogger, get_db_connection, set_rls_user
 
 # Module-level logger reserved for future debugging hooks (not used directly yet).
 logger = logging.getLogger(__name__)
@@ -171,6 +171,8 @@ def store_document(
     user_id: int,
     title: str,
     parsed: ParsedDocument,
+    *,
+    tracker: Optional[ProcessingJobLogger] = None,
 ) -> StoredDocument:
     """Persist the parsed document and its embeddings into PostgreSQL."""
 
@@ -211,39 +213,80 @@ def store_document(
         rev_id = cur.fetchone()[0]
 
         chunk_ids: List[int] = []
-        for chunk in parsed.chunks:
-            cur.execute(
-                """
-                INSERT INTO doc_chunk (doc_id, rev_id, position, page_from, page_to, heading, text)
-                VALUES (%s, %s, %s, %s, %s, %s, %s)
-                RETURNING chunk_id
-                """,
-                (
-                    doc_id,
-                    rev_id,
-                    chunk.position,
-                    chunk.page_from,
-                    chunk.page_to,
-                    chunk.heading,
-                    chunk.text,
-                ),
+        chunk_job_id = None
+        if tracker:
+            chunk_job_id = tracker.start_step(
+                "chunk",
+                doc_id=doc_id,
+                detail={"chunk_count": len(parsed.chunks)},
             )
-            chunk_id = cur.fetchone()[0]
-            chunk_ids.append(chunk_id)
+        try:
+            for chunk in parsed.chunks:
+                cur.execute(
+                    """
+                    INSERT INTO doc_chunk (doc_id, rev_id, position, page_from, page_to, heading, text)
+                    VALUES (%s, %s, %s, %s, %s, %s, %s)
+                    RETURNING chunk_id
+                    """,
+                    (
+                        doc_id,
+                        rev_id,
+                        chunk.position,
+                        chunk.page_from,
+                        chunk.page_to,
+                        chunk.heading,
+                        chunk.text,
+                    ),
+                )
+                chunk_id = cur.fetchone()[0]
+                chunk_ids.append(chunk_id)
+        except Exception as exc:
+            if tracker and chunk_job_id is not None:
+                tracker.fail_step(
+                    chunk_job_id,
+                    detail={"error": str(exc)},
+                )
+            raise
+
+        if tracker and chunk_job_id is not None:
+            tracker.succeed_step(
+                chunk_job_id,
+                detail={"chunk_count": len(chunk_ids)},
+                doc_id=doc_id,
+            )
 
         embeddings = _embeddings.embed_documents([chunk.text for chunk in parsed.chunks])
-        for chunk_id, embedding_vector in zip(chunk_ids, embeddings):
-            cur.execute(
-                """
-                INSERT INTO doc_chunk_embedding (chunk_id, model_name, dim, embedding)
-                VALUES (%s, %s, %s, %s)
-                """,
-                (
-                    chunk_id,
-                    EMBEDDING_MODEL,
-                    EMBEDDING_DIM,
-                    embedding_vector,
-                ),
+        embed_job_id = None
+        if tracker:
+            embed_job_id = tracker.start_step(
+                "embed",
+                doc_id=doc_id,
+                detail={"model": EMBEDDING_MODEL, "chunk_count": len(chunk_ids)},
+            )
+        try:
+            for chunk_id, embedding_vector in zip(chunk_ids, embeddings):
+                cur.execute(
+                    """
+                    INSERT INTO doc_chunk_embedding (chunk_id, model_name, dim, embedding)
+                    VALUES (%s, %s, %s, %s)
+                    """,
+                    (
+                        chunk_id,
+                        EMBEDDING_MODEL,
+                        EMBEDDING_DIM,
+                        embedding_vector,
+                    ),
+                )
+        except Exception as exc:
+            if tracker and embed_job_id is not None:
+                tracker.fail_step(embed_job_id, detail={"error": str(exc)})
+            raise
+
+        if tracker and embed_job_id is not None:
+            tracker.succeed_step(
+                embed_job_id,
+                detail={"model": EMBEDDING_MODEL, "chunk_count": len(chunk_ids)},
+                doc_id=doc_id,
             )
 
         cur.execute(
@@ -267,10 +310,38 @@ def ingest_document(
     mime_type: Optional[str] = None,
     enable_ocr: bool = False,
     conn=None,
+    *,
+    tracker: Optional[ProcessingJobLogger] = None,
 ) -> Tuple[ParsedDocument, StoredDocument]:
     """High level helper used by LangGraph nodes to ingest a document."""
 
-    parsed = parse_document(file_bytes=file_bytes, file_name=file_name, mime_type=mime_type, enable_ocr=enable_ocr)
+    parse_job_id = None
+    if tracker:
+        parse_job_id = tracker.start_step(
+            "parse",
+            detail={"file_name": file_name, "enable_ocr": enable_ocr},
+        )
+    try:
+        parsed = parse_document(
+            file_bytes=file_bytes,
+            file_name=file_name,
+            mime_type=mime_type,
+            enable_ocr=enable_ocr,
+        )
+    except Exception as exc:
+        if tracker and parse_job_id is not None:
+            tracker.fail_step(parse_job_id, detail={"error": str(exc)})
+        raise
+    if tracker and parse_job_id is not None:
+        tracker.succeed_step(
+            parse_job_id,
+            detail={
+                "file_name": file_name,
+                "page_count": parsed.page_count,
+                "chunk_count": len(parsed.chunks),
+                "pii_flag": parsed.pii_flag,
+            },
+        )
     close_conn = False
     if conn is None:
         conn = get_db_connection()
@@ -278,7 +349,14 @@ def ingest_document(
 
     try:
         set_rls_user(conn, firm_id)
-        stored = store_document(conn, firm_id, user_id, title=file_name, parsed=parsed)
+        stored = store_document(
+            conn,
+            firm_id,
+            user_id,
+            title=file_name,
+            parsed=parsed,
+            tracker=tracker,
+        )
     finally:
         if close_conn:
             conn.close()

--- a/src/workflows.py
+++ b/src/workflows.py
@@ -1,0 +1,221 @@
+"""High level helpers that orchestrate ingestion and drafting workflows."""
+from __future__ import annotations
+
+from typing import Dict, List, Optional, Tuple
+
+from .db_utils import ProcessingJobLogger
+from .file_processor import ParsedDocument, StoredDocument, ingest_document
+from .nodes import drafting_node, rag_chain_node, simulation_node, summarize_node
+from .state import AssistantState
+
+
+def fetch_document_overview(conn, doc_id: int) -> Dict[str, object]:
+    """Return basic metadata for a document or raise if it is missing."""
+
+    with conn.cursor() as cur:
+        cur.execute(
+            """
+            SELECT doc_id, title, page_count, pii_flag
+              FROM document
+             WHERE doc_id = %s
+            """,
+            (doc_id,),
+        )
+        row = cur.fetchone()
+    if not row:
+        raise LookupError("문서를 찾을 수 없습니다.")
+    return {
+        "doc_id": row[0],
+        "title": row[1],
+        "page_count": row[2],
+        "pii_flag": row[3],
+    }
+
+
+def fetch_document_chunks(conn, doc_id: int) -> List[Dict[str, object]]:
+    """Return stored chunks for a document ordered by their position."""
+
+    with conn.cursor() as cur:
+        cur.execute(
+            """
+            SELECT chunk_id, position, text
+              FROM doc_chunk
+             WHERE doc_id = %s
+             ORDER BY position
+            """,
+            (doc_id,),
+        )
+        rows = cur.fetchall()
+
+    return [
+        {
+            "chunk_id": row[0],
+            "position": row[1],
+            "text": row[2],
+        }
+        for row in rows
+    ]
+
+
+def fetch_embedding_overview(conn, doc_id: int) -> List[Dict[str, object]]:
+    """Return aggregated embedding information per model for a document."""
+
+    with conn.cursor() as cur:
+        cur.execute(
+            """
+            SELECT e.model_name, COUNT(*), MIN(e.created_at), MAX(e.created_at)
+              FROM doc_chunk_embedding e
+              JOIN doc_chunk c ON c.chunk_id = e.chunk_id
+             WHERE c.doc_id = %s
+             GROUP BY e.model_name
+             ORDER BY e.model_name
+            """,
+            (doc_id,),
+        )
+        rows = cur.fetchall()
+
+    return [
+        {
+            "model_name": row[0],
+            "chunk_count": row[1],
+            "first_indexed_at": row[2].isoformat() if row[2] else None,
+            "last_indexed_at": row[3].isoformat() if row[3] else None,
+        }
+        for row in rows
+    ]
+
+
+def _run_generation_pipeline(state: AssistantState, include_simulation: bool = True) -> AssistantState:
+    """Run the summarize → rag → draft → simulate sequence on a state."""
+
+    state = summarize_node(state)
+    state = rag_chain_node(state)
+    state = drafting_node(state)
+    if include_simulation:
+        state = simulation_node(state)
+    return state
+
+
+def run_pipeline_for_document(
+    conn,
+    doc_id: int,
+    firm_id: int,
+    user_id: int,
+    *,
+    include_simulation: bool = True,
+    tracker: Optional[ProcessingJobLogger] = None,
+) -> Tuple[AssistantState, Dict[str, object], List[Dict[str, object]], Optional[int]]:
+    """Execute the drafting pipeline for a stored document."""
+
+    overview = fetch_document_overview(conn, doc_id)
+    chunks = fetch_document_chunks(conn, doc_id)
+    if not chunks:
+        raise ValueError("문서 청크가 존재하지 않습니다. 파싱 과정을 확인하세요.")
+
+    state: AssistantState = {
+        "firm_id": firm_id,
+        "user_id": user_id,
+        "doc_id": doc_id,
+        "chunk_ids": [chunk["chunk_id"] for chunk in chunks],
+        "raw_text": "\n\n".join(chunk["text"] for chunk in chunks),
+    }
+
+    draft_job_id: Optional[int] = None
+    if tracker:
+        draft_job_id = tracker.start_step(
+            "draft",
+            doc_id=doc_id,
+            detail={
+                "include_simulation": include_simulation,
+                "chunk_count": len(chunks),
+            },
+        )
+    try:
+        state = _run_generation_pipeline(state, include_simulation=include_simulation)
+    except Exception as exc:
+        if tracker and draft_job_id is not None:
+            tracker.fail_step(draft_job_id, detail={"error": str(exc)})
+        raise
+
+    if tracker and draft_job_id is not None:
+        tracker.succeed_step(
+            draft_job_id,
+            detail={
+                "include_simulation": include_simulation,
+                "chunk_count": len(chunks),
+                "summary_length": len(state.get("summary") or ""),
+            },
+            doc_id=doc_id,
+        )
+
+    return state, overview, chunks, draft_job_id
+
+
+def ingest_and_run_pipeline(
+    conn,
+    *,
+    firm_id: int,
+    user_id: int,
+    file_bytes: bytes,
+    file_name: str,
+    mime_type: Optional[str] = None,
+    enable_ocr: bool = False,
+    include_simulation: bool = True,
+    tracker: Optional[ProcessingJobLogger] = None,
+) -> Dict[str, object]:
+    """Ingest a document and immediately run the drafting pipeline."""
+
+    workflow_job_id: Optional[int] = None
+    if tracker:
+        workflow_job_id = tracker.start_step(
+            "workflow",
+            detail={
+                "file_name": file_name,
+                "include_simulation": include_simulation,
+            },
+        )
+
+    try:
+        parsed, stored = ingest_document(
+            firm_id=firm_id,
+            user_id=user_id,
+            file_bytes=file_bytes,
+            file_name=file_name,
+            mime_type=mime_type,
+            enable_ocr=enable_ocr,
+            conn=conn,
+            tracker=tracker,
+        )
+        state, overview, chunks, draft_job_id = run_pipeline_for_document(
+            conn,
+            stored.doc_id,
+            firm_id,
+            user_id,
+            include_simulation=include_simulation,
+            tracker=tracker,
+        )
+    except Exception as exc:
+        if tracker and workflow_job_id is not None:
+            tracker.fail_step(workflow_job_id, detail={"error": str(exc)})
+        raise
+
+    if tracker and workflow_job_id is not None:
+        tracker.succeed_step(
+            workflow_job_id,
+            detail={
+                "include_simulation": include_simulation,
+                "chunk_count": len(chunks),
+                "summary_length": len(state.get("summary") or ""),
+            },
+            doc_id=stored.doc_id,
+        )
+
+    return {
+        "parsed": parsed,
+        "stored": stored,
+        "state": state,
+        "overview": overview,
+        "chunks": chunks,
+        "workflow_job_id": workflow_job_id,
+        "draft_job_id": draft_job_id,
+    }


### PR DESCRIPTION
## Summary
- add shared workflow helpers to orchestrate ingestion, drafting, and simulation steps
- extend the FastAPI layer with a /workflow endpoint and reuse the helpers for draft generation responses
- permit draft/workflow job steps in the processing_job schema so logging covers the combined pipeline

## Testing
- python -m compileall src

------
https://chatgpt.com/codex/tasks/task_e_68f6fd4e8a8883249ef994e9297afb31