### PR TITLE
Register pgvector adapters for embeddings

### DIFF
--- a/batch_learn.py
+++ b/batch_learn.py
@@ -11,6 +11,8 @@ from typing import Iterable, List
 from rich import print
 from rich.progress import track
 
+from pgvector.utils import Vector
+
 from src.db_utils import get_db_connection
 from src.file_processor import EMBEDDING_DIM, EMBEDDING_MODEL
 from langchain_community.embeddings import SentenceTransformerEmbeddings
@@ -88,7 +90,7 @@ def ingest_precedents(cases: Iterable[dict]) -> None:
                             section_id,
                             EMBEDDING_MODEL,
                             EMBEDDING_DIM,
-                            vectors[idx],
+                            Vector(vectors[idx]),
                         ),
                     )
         conn.commit()

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,6 +6,7 @@ redis
 rich
 sentence-transformers
 psycopg2-binary
+pgvector
 langchain-postgres
 python-dotenv
 langchain-smith

--- a/src/db_utils.py
+++ b/src/db_utils.py
@@ -6,18 +6,21 @@ import os
 from typing import Any, Dict, List, Optional
 
 import psycopg2
+from pgvector.psycopg2 import register_vector
 
 
 def get_db_connection():
     """Create a new PostgreSQL connection using environment variables."""
 
-    return psycopg2.connect(
+    conn = psycopg2.connect(
         host=os.getenv("POSTGRES_HOST", "localhost"),
         database=os.getenv("POSTGRES_DB", "legal_db"),
         user=os.getenv("POSTGRES_USER", "user"),
         password=os.getenv("POSTGRES_PASSWORD", "password"),
         port=os.getenv("POSTGRES_PORT", 5432),
     )
+    register_vector(conn)
+    return conn
 
 
 def set_rls_user(conn, firm_id: int) -> None:

--- a/src/file_processor.py
+++ b/src/file_processor.py
@@ -13,6 +13,7 @@ from typing import List, Optional, Tuple
 import fitz  # PyMuPDF
 from langchain.text_splitter import RecursiveCharacterTextSplitter
 from langchain_community.embeddings import SentenceTransformerEmbeddings
+from pgvector.utils import Vector
 
 try:  # Optional dependency for DOCX parsing
     import docx  # type: ignore
@@ -274,7 +275,7 @@ def store_document(
                         chunk_id,
                         EMBEDDING_MODEL,
                         EMBEDDING_DIM,
-                        embedding_vector,
+                        Vector(embedding_vector),
                     ),
                 )
         except Exception as exc:


### PR DESCRIPTION
## Summary
- add pgvector to the runtime requirements and register the adapter on every psycopg2 connection
- wrap document and precedent embedding inserts with pgvector.Vector so psycopg2 can adapt the payloads after registration

## Testing
- `python - <<'PY' ... PY`

------
https://chatgpt.com/codex/tasks/task_e_68f72c7b79288324b0e3d18216ddf03d