### PR TITLE
Add OCR ingestion utilities for public and private precedents

### DIFF
--- a/scripts/ingest_precedents_from_ocr.py
+++ b/scripts/ingest_precedents_from_ocr.py
@@ -1,0 +1,388 @@
+"""OCR 기반으로 공용 판례 데이터를 데이터베이스에 적재하는 도구."""
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+import os
+import re
+from dataclasses import dataclass
+from datetime import date, datetime
+from pathlib import Path
+from typing import Dict, Iterable, List, Optional, Sequence
+
+from dotenv import load_dotenv
+from langchain_community.embeddings import SentenceTransformerEmbeddings
+from pgvector.utils import Vector
+
+from src.db_utils import get_db_connection
+from src.file_processor import EMBEDDING_DIM, EMBEDDING_MODEL
+from src.naver_ocr import NaverOCRError, NaverOCRClient
+
+
+LOGGER = logging.getLogger("precedent_ingest")
+_EMBEDDER: Optional[SentenceTransformerEmbeddings] = None
+
+
+@dataclass
+class PrecedentSection:
+    heading: Optional[str]
+    text: str
+    order: int
+
+
+_KEYWORD_HEADINGS = (
+    "판시사항",
+    "판결요지",
+    "판결요약",
+    "주문",
+    "이유",
+    "요지",
+    "사실관계",
+    "판단",
+    "쟁점",
+    "결론",
+    "참고판례",
+)
+
+
+def _load_sidecar_metadata(file_path: Path) -> Dict[str, str]:
+    sidecar = file_path.with_suffix(".json")
+    if not sidecar.exists():
+        return {}
+    try:
+        with sidecar.open("r", encoding="utf-8") as handle:
+            data = json.load(handle)
+            if isinstance(data, dict):
+                return {str(key): str(value) for key, value in data.items() if value is not None}
+    except (json.JSONDecodeError, OSError) as exc:
+        LOGGER.warning("%s 메타데이터 파일을 읽는 중 오류: %s", sidecar.name, exc)
+    return {}
+
+
+def _parse_filename_metadata(stem: str) -> Dict[str, str]:
+    tokens = [token.strip() for token in re.split(r"[_\-]+", stem) if token.strip()]
+    court = None
+    case_no = None
+    title = None
+    case_date = None
+
+    for token in tokens:
+        if court is None and token.endswith("법원"):
+            court = token
+            continue
+        if case_no is None and re.match(r"\d{4}[가-힣A-Za-z]{1,3}\d+", token):
+            case_no = token
+            continue
+        if case_date is None and re.match(r"\d{4}[./-]\d{1,2}[./-]\d{1,2}", token):
+            case_date = token
+            continue
+
+    if tokens:
+        candidate = tokens[-1]
+        if candidate not in {court, case_no, case_date}:
+            title = candidate
+
+    metadata: Dict[str, str] = {}
+    if court:
+        metadata["court"] = court
+    if case_no:
+        metadata["case_no"] = case_no
+    if title:
+        metadata["title"] = title
+    if case_date:
+        metadata["date"] = case_date
+    return metadata
+
+
+def _parse_date(value: Optional[str]) -> Optional[date]:
+    if not value:
+        return None
+    for fmt in ("%Y-%m-%d", "%Y.%m.%d", "%Y/%m/%d", "%Y%m%d"):
+        try:
+            return datetime.strptime(value, fmt).date()
+        except ValueError:
+            continue
+    return None
+
+
+def _looks_like_heading(line: str) -> bool:
+    condensed = line.replace(" ", "")
+    if len(condensed) <= 4 and condensed.endswith(":"):
+        return True
+    if any(keyword in condensed for keyword in _KEYWORD_HEADINGS):
+        return True
+    if re.match(r"^제?\d+\.?$", condensed):
+        return True
+    if re.match(r"^[IVX]+\.", condensed):
+        return True
+    return False
+
+
+def _parse_precedent_text(text: str) -> List[PrecedentSection]:
+    lines = [line.strip() for line in text.splitlines() if line.strip()]
+    sections: List[PrecedentSection] = []
+    heading: Optional[str] = None
+    body: List[str] = []
+
+    def flush() -> None:
+        nonlocal heading, body
+        if not body and not heading:
+            return
+        content = "\n".join(body).strip()
+        if not content and heading:
+            content = heading
+        sections.append(
+            PrecedentSection(
+                heading=heading,
+                text=content,
+                order=len(sections),
+            )
+        )
+        heading = None
+        body = []
+
+    for line in lines:
+        if _looks_like_heading(line):
+            flush()
+            heading = line
+            continue
+        body.append(line)
+
+    flush()
+
+    if not sections and lines:
+        sections.append(PrecedentSection(heading=None, text="\n".join(lines), order=0))
+
+    return sections
+
+
+def _embed_texts(texts: Sequence[str]) -> List[List[float]]:
+    global _EMBEDDER
+    if _EMBEDDER is None:
+        _EMBEDDER = SentenceTransformerEmbeddings(model_name=EMBEDDING_MODEL)
+    return _EMBEDDER.embed_documents(list(texts))
+
+
+def _store_precedent(
+    *,
+    conn,
+    metadata: Dict[str, str],
+    sections: Sequence[PrecedentSection],
+    source_path: Path,
+) -> None:
+    if not sections:
+        LOGGER.warning("%s: OCR 결과에서 본문을 추출할 수 없어 건너뜁니다.", source_path.name)
+        return
+
+    embeddings = _embed_texts([section.text for section in sections])
+
+    case_no = metadata.get("case_no")
+    court = metadata.get("court")
+    case_date = _parse_date(metadata.get("date"))
+    title = metadata.get("title") or source_path.stem
+    summary = metadata.get("summary")
+
+    with conn.cursor() as cur:
+        case_id = None
+        if case_no:
+            cur.execute(
+                """
+                SELECT case_id
+                  FROM precedent
+                 WHERE case_no = %s AND (court = %s OR (court IS NULL AND %s IS NULL))
+                """,
+                (case_no, court, court),
+            )
+            row = cur.fetchone()
+            if row:
+                case_id = row[0]
+                cur.execute(
+                    """
+                    UPDATE precedent
+                       SET court = %s,
+                           date = %s,
+                           title = %s,
+                           summary = %s,
+                           meta = %s
+                     WHERE case_id = %s
+                    """,
+                    (
+                        court,
+                        case_date,
+                        title,
+                        summary,
+                        json.dumps({"source_file": source_path.name, **metadata}),
+                        case_id,
+                    ),
+                )
+                cur.execute("DELETE FROM precedent_section WHERE case_id = %s", (case_id,))
+
+        if case_id is None:
+            cur.execute(
+                """
+                INSERT INTO precedent (court, case_no, date, title, summary, meta)
+                VALUES (%s, %s, %s, %s, %s, %s)
+                RETURNING case_id
+                """,
+                (
+                    court,
+                    case_no,
+                    case_date,
+                    title,
+                    summary,
+                    json.dumps({"source_file": source_path.name, **metadata}),
+                ),
+            )
+            case_id = cur.fetchone()[0]
+
+        for section, embedding in zip(sections, embeddings):
+            cur.execute(
+                """
+                INSERT INTO precedent_section (case_id, position, heading, text, meta)
+                VALUES (%s, %s, %s, %s, %s)
+                RETURNING section_id
+                """,
+                (
+                    case_id,
+                    section.order,
+                    section.heading,
+                    section.text,
+                    json.dumps({"order": section.order}),
+                ),
+            )
+            section_id = cur.fetchone()[0]
+            cur.execute(
+                """
+                INSERT INTO precedent_section_embedding (section_id, model_name, dim, embedding)
+                VALUES (%s, %s, %s, %s)
+                """,
+                (
+                    section_id,
+                    EMBEDDING_MODEL,
+                    EMBEDDING_DIM,
+                    Vector(embedding),
+                ),
+            )
+
+    conn.commit()
+    LOGGER.info("%s: %d개의 섹션을 저장했습니다.", source_path.name, len(sections))
+
+
+def _iter_input_files(directory: Path, pattern: str) -> Iterable[Path]:
+    yield from sorted(directory.glob(pattern))
+
+
+def ingest_directory(
+    *,
+    directory: Path,
+    pattern: str,
+    client: NaverOCRClient,
+    default_metadata: Dict[str, str],
+) -> None:
+    conn = get_db_connection()
+    try:
+        for file_path in _iter_input_files(directory, pattern):
+            LOGGER.info("%s OCR 처리 시작", file_path.name)
+            try:
+                extracted_text = client.infer_file(str(file_path))
+            except (ValueError, NaverOCRError) as exc:
+                LOGGER.error("%s OCR 실패: %s", file_path.name, exc)
+                continue
+
+            if not extracted_text.strip():
+                LOGGER.warning("%s OCR 결과가 비어 있어 건너뜁니다.", file_path.name)
+                continue
+
+            metadata = dict(default_metadata)
+            metadata.update(_parse_filename_metadata(file_path.stem))
+            metadata.update(_load_sidecar_metadata(file_path))
+            sections = _parse_precedent_text(extracted_text)
+            _store_precedent(conn=conn, metadata=metadata, sections=sections, source_path=file_path)
+    finally:
+        conn.close()
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--input-dir",
+        type=Path,
+        default=Path("기준법예제"),
+        help="OCR을 적용할 판례 파일이 위치한 디렉터리",
+    )
+    parser.add_argument(
+        "--pattern",
+        default="*.pdf",
+        help="처리할 파일 패턴 (glob)",
+    )
+    parser.add_argument(
+        "--default-court",
+        default=os.getenv("DEFAULT_PRECEDENT_COURT"),
+        help="메타데이터에 사용할 기본 법원명",
+    )
+    parser.add_argument(
+        "--default-summary",
+        default=os.getenv("DEFAULT_PRECEDENT_SUMMARY"),
+        help="요약문 기본값",
+    )
+    parser.add_argument(
+        "--log-level",
+        default=os.getenv("LOG_LEVEL", "INFO"),
+        help="로깅 레벨",
+    )
+    parser.add_argument(
+        "--invoke-url",
+        default=os.getenv("NAVER_OCR_INVOKE_URL"),
+        help="Naver OCR 호출 URL (환경변수 우선)",
+    )
+    parser.add_argument(
+        "--secret-key",
+        default=os.getenv("NAVER_OCR_SECRET_KEY"),
+        help="Naver OCR 시크릿 키",
+    )
+    parser.add_argument(
+        "--api-key-id",
+        default=os.getenv("NAVER_OCR_API_KEY_ID"),
+        help="Naver API Gateway Key ID",
+    )
+    parser.add_argument(
+        "--api-key",
+        default=os.getenv("NAVER_OCR_API_KEY"),
+        help="Naver API Gateway Key",
+    )
+    return parser.parse_args()
+
+
+def main() -> None:
+    load_dotenv()
+    args = parse_args()
+
+    logging.basicConfig(level=getattr(logging, args.log_level.upper(), logging.INFO))
+
+    client = NaverOCRClient(
+        invoke_url=args.invoke_url,
+        secret_key=args.secret_key,
+        api_key_id=args.api_key_id,
+        api_key=args.api_key,
+    )
+
+    default_metadata = {
+        key: value
+        for key, value in {
+            "court": args.default_court,
+            "summary": args.default_summary,
+        }.items()
+        if value
+    }
+
+    ingest_directory(
+        directory=args.input_dir,
+        pattern=args.pattern,
+        client=client,
+        default_metadata=default_metadata,
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/ingest_private_precedents_from_ocr.py
+++ b/scripts/ingest_private_precedents_from_ocr.py
@@ -1,0 +1,206 @@
+"""OCR 기반으로 전용(개인) 판례 문서를 적재하는 도구."""
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+import os
+from pathlib import Path
+from typing import Dict, Iterable, List, Optional
+
+from dotenv import load_dotenv
+
+from src.db_utils import get_db_connection, set_rls_user
+from src.file_processor import build_parsed_document_from_text, store_document
+from src.naver_ocr import NaverOCRError, NaverOCRClient
+
+
+LOGGER = logging.getLogger("private_precedent_ingest")
+DEFAULT_OCR_ENGINE = "naver_clova"
+
+
+def _load_sidecar_metadata(file_path: Path) -> Dict[str, object]:
+    sidecar = file_path.with_suffix(".json")
+    if not sidecar.exists():
+        return {}
+    try:
+        with sidecar.open("r", encoding="utf-8") as handle:
+            data = json.load(handle)
+            if isinstance(data, dict):
+                return data
+    except (json.JSONDecodeError, OSError) as exc:
+        LOGGER.warning("%s 메타데이터 파일을 읽는 중 오류: %s", sidecar.name, exc)
+    return {}
+
+
+def _normalise_tags(value: Optional[object]) -> Optional[List[str]]:
+    if value is None:
+        return None
+    if isinstance(value, list):
+        return [str(item).strip() for item in value if str(item).strip()]
+    if isinstance(value, str):
+        return [item.strip() for item in value.split(",") if item.strip()]
+    return [str(value).strip()]
+
+
+def _iter_input_files(directory: Path, pattern: str) -> Iterable[Path]:
+    yield from sorted(directory.glob(pattern))
+
+
+def _update_private_meta(conn, doc_id: int, metadata: Dict[str, object]) -> None:
+    case_type = metadata.get("case_type") or metadata.get("category")
+    tags = _normalise_tags(metadata.get("tags"))
+    opponent = metadata.get("opponent")
+    notes = metadata.get("notes")
+    court = metadata.get("court")
+    case_no = metadata.get("case_no")
+
+    with conn.cursor() as cur:
+        cur.execute(
+            """
+            UPDATE private_case_meta
+               SET case_type = COALESCE(%s, case_type),
+                   court = COALESCE(%s, court),
+                   case_no = COALESCE(%s, case_no),
+                   opponent = COALESCE(%s, opponent),
+                   tags = CASE WHEN %s IS NULL THEN tags ELSE %s END,
+                   notes = COALESCE(%s, notes)
+             WHERE doc_id = %s
+            """,
+            (
+                case_type,
+                court,
+                case_no,
+                opponent,
+                tags,
+                tags,
+                notes,
+                doc_id,
+            ),
+        )
+    conn.commit()
+
+
+def ingest_directory(
+    *,
+    directory: Path,
+    pattern: str,
+    client: NaverOCRClient,
+    firm_id: int,
+    user_id: int,
+    defaults: Dict[str, object],
+    ocr_engine: str,
+) -> None:
+    conn = get_db_connection()
+    try:
+        set_rls_user(conn, firm_id)
+        for file_path in _iter_input_files(directory, pattern):
+            LOGGER.info("%s OCR 처리 시작", file_path.name)
+            try:
+                extracted_text = client.infer_file(str(file_path))
+            except (ValueError, NaverOCRError) as exc:
+                LOGGER.error("%s OCR 실패: %s", file_path.name, exc)
+                continue
+
+            if not extracted_text.strip():
+                LOGGER.warning("%s OCR 결과가 비어 있어 건너뜁니다.", file_path.name)
+                continue
+
+            metadata: Dict[str, object] = dict(defaults)
+            metadata.update(_load_sidecar_metadata(file_path))
+
+            title = str(metadata.get("title") or file_path.stem)
+            try:
+                parsed = build_parsed_document_from_text(
+                    extracted_text,
+                    file_ext="ocr.txt",
+                    mime_type="text/plain",
+                    ocr_used=True,
+                    ocr_engine=ocr_engine,
+                )
+            except ValueError as exc:
+                LOGGER.warning("%s ParsedDocument 생성 실패: %s", file_path.name, exc)
+                continue
+
+            stored = store_document(
+                conn,
+                firm_id,
+                user_id,
+                title=title,
+                parsed=parsed,
+                source_type="precedent",
+            )
+
+            _update_private_meta(conn, stored.doc_id, metadata)
+            LOGGER.info("%s: doc_id=%d, chunk=%d개 저장", file_path.name, stored.doc_id, len(stored.chunk_ids))
+    finally:
+        conn.close()
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--firm-id", type=int, required=True, help="저장할 회사(firm) ID")
+    parser.add_argument("--user-id", type=int, required=True, help="업로드를 수행하는 사용자 ID")
+    parser.add_argument(
+        "--input-dir",
+        type=Path,
+        default=Path("기준법예제"),
+        help="OCR을 적용할 파일이 위치한 디렉터리",
+    )
+    parser.add_argument("--pattern", default="*.pdf", help="처리할 파일 패턴 (glob)")
+    parser.add_argument("--default-case-type", default=os.getenv("DEFAULT_PRIVATE_CASE_TYPE"))
+    parser.add_argument("--default-court", default=os.getenv("DEFAULT_PRIVATE_COURT"))
+    parser.add_argument("--default-opponent", default=os.getenv("DEFAULT_PRIVATE_OPPONENT"))
+    parser.add_argument(
+        "--default-tags",
+        default=os.getenv("DEFAULT_PRIVATE_TAGS"),
+        help="콤마로 구분된 태그 기본값",
+    )
+    parser.add_argument("--default-notes", default=os.getenv("DEFAULT_PRIVATE_NOTES"))
+    parser.add_argument("--ocr-engine", default=DEFAULT_OCR_ENGINE, help="저장할 OCR 엔진 이름")
+    parser.add_argument("--log-level", default=os.getenv("LOG_LEVEL", "INFO"))
+    parser.add_argument("--invoke-url", default=os.getenv("NAVER_OCR_INVOKE_URL"))
+    parser.add_argument("--secret-key", default=os.getenv("NAVER_OCR_SECRET_KEY"))
+    parser.add_argument("--api-key-id", default=os.getenv("NAVER_OCR_API_KEY_ID"))
+    parser.add_argument("--api-key", default=os.getenv("NAVER_OCR_API_KEY"))
+    return parser.parse_args()
+
+
+def main() -> None:
+    load_dotenv()
+    args = parse_args()
+
+    logging.basicConfig(level=getattr(logging, args.log_level.upper(), logging.INFO))
+
+    client = NaverOCRClient(
+        invoke_url=args.invoke_url,
+        secret_key=args.secret_key,
+        api_key_id=args.api_key_id,
+        api_key=args.api_key,
+    )
+
+    defaults: Dict[str, object] = {
+        "case_type": args.default_case_type,
+        "court": args.default_court,
+        "opponent": args.default_opponent,
+        "tags": args.default_tags,
+        "notes": args.default_notes,
+    }
+    defaults = {key: value for key, value in defaults.items() if value}
+
+    if "tags" in defaults:
+        defaults["tags"] = _normalise_tags(defaults["tags"])
+
+    ingest_directory(
+        directory=args.input_dir,
+        pattern=args.pattern,
+        client=client,
+        firm_id=args.firm_id,
+        user_id=args.user_id,
+        defaults=defaults,
+        ocr_engine=args.ocr_engine,
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/src/file_processor.py
+++ b/src/file_processor.py
@@ -85,6 +85,44 @@ def _detect_pii(text: str) -> bool:
     )
 
 
+def build_parsed_document_from_text(
+    text: str,
+    *,
+    file_ext: str = "txt",
+    mime_type: Optional[str] = "text/plain",
+    ocr_used: bool = False,
+    ocr_engine: Optional[str] = None,
+) -> ParsedDocument:
+    """Construct a :class:`ParsedDocument` from raw text."""
+
+    normalised_text = text.strip()
+    if not normalised_text:
+        raise ValueError("텍스트가 비어 있어 ParsedDocument를 생성할 수 없습니다.")
+
+    encoded = normalised_text.encode("utf-8")
+
+    chunks: List[ParsedChunk] = []
+    for idx, chunk_text in enumerate(_text_splitter.split_text(normalised_text)):
+        chunks.append(ParsedChunk(text=chunk_text, position=idx))
+
+    byte_size = len(encoded)
+    sha256 = hashlib.sha256(encoded).hexdigest()
+    page_estimate = max(1, len(normalised_text) // 2000)
+
+    return ParsedDocument(
+        text=normalised_text,
+        file_ext=file_ext,
+        mime_type=mime_type,
+        page_count=page_estimate,
+        byte_size=byte_size,
+        sha256=sha256,
+        pii_flag=_detect_pii(normalised_text),
+        chunks=chunks,
+        ocr_used=ocr_used,
+        ocr_engine=ocr_engine,
+    )
+
+
 def _extract_pdf_text(file_bytes: bytes) -> Tuple[str, int]:
     with fitz.open(stream=file_bytes, filetype="pdf") as doc:
         pages = [page.get_text("text") for page in doc]
@@ -174,6 +212,7 @@ def store_document(
     parsed: ParsedDocument,
     *,
     tracker: Optional[ProcessingJobLogger] = None,
+    source_type: str = "upload",
 ) -> StoredDocument:
     """Persist the parsed document and its embeddings into PostgreSQL."""
 
@@ -181,13 +220,14 @@ def store_document(
         cur.execute(
             """
             INSERT INTO document (firm_id, user_id, title, source_type, mime_type, file_ext, sha256, bytes, page_count, pii_flag)
-            VALUES (%s, %s, %s, 'upload', %s, %s, %s, %s, %s, %s)
+            VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
             RETURNING doc_id
             """,
             (
                 firm_id,
                 user_id,
                 title,
+                source_type,
                 parsed.mime_type,
                 parsed.file_ext,
                 parsed.sha256,
@@ -313,6 +353,7 @@ def ingest_document(
     conn=None,
     *,
     tracker: Optional[ProcessingJobLogger] = None,
+    source_type: str = "upload",
 ) -> Tuple[ParsedDocument, StoredDocument]:
     """High level helper used by LangGraph nodes to ingest a document."""
 
@@ -357,6 +398,7 @@ def ingest_document(
             title=file_name,
             parsed=parsed,
             tracker=tracker,
+            source_type=source_type,
         )
     finally:
         if close_conn:


### PR DESCRIPTION
## Summary
- add a helper to construct parsed documents from OCR text and allow specifying the document source type when persisting uploads
- add an OCR ingestion script that writes public precedents into the precedent tables with embeddings
- add an OCR ingestion script to persist private precedent files into firm-specific storage and metadata tables

## Testing
- python -m compileall src scripts

------
https://chatgpt.com/codex/tasks/task_e_68f825e019748324b8ab5cd7739ce6ac