### PR TITLE
Fix pgvector ingestion by adapting numpy arrays

### DIFF
--- a/batch_learn.py
+++ b/batch_learn.py
@@ -8,10 +8,9 @@ from datetime import datetime
 from pathlib import Path
 from typing import Iterable, List
 
+import numpy as np
 from rich import print
 from rich.progress import track
-
-from pgvector.utils import Vector
 
 from src.db_utils import get_db_connection
 from src.file_processor import EMBEDDING_DIM, EMBEDDING_MODEL
@@ -90,7 +89,7 @@ def ingest_precedents(cases: Iterable[dict]) -> None:
                             section_id,
                             EMBEDDING_MODEL,
                             EMBEDDING_DIM,
-                            Vector(vectors[idx]),
+                            np.asarray(vectors[idx], dtype=np.float32),
                         ),
                     )
         conn.commit()

--- a/scripts/ingest_precedents_from_ocr.py
+++ b/scripts/ingest_precedents_from_ocr.py
@@ -11,9 +11,9 @@ from datetime import date, datetime
 from pathlib import Path
 from typing import Dict, Iterable, List, Optional, Sequence
 
+import numpy as np
 from dotenv import load_dotenv
 from langchain_community.embeddings import SentenceTransformerEmbeddings
-from pgvector.utils import Vector
 
 from src.db_utils import get_db_connection
 from src.file_processor import EMBEDDING_DIM, EMBEDDING_MODEL
@@ -261,7 +261,7 @@ def _store_precedent(
                     section_id,
                     EMBEDDING_MODEL,
                     EMBEDDING_DIM,
-                    Vector(embedding),
+                    np.asarray(embedding, dtype=np.float32),
                 ),
             )
 

--- a/scripts/ingest_statutes_from_ocr.py
+++ b/scripts/ingest_statutes_from_ocr.py
@@ -10,9 +10,9 @@ from datetime import date
 from pathlib import Path
 from typing import Iterable, List, Optional, Sequence
 
+import numpy as np
 from dotenv import load_dotenv
 from langchain_community.embeddings import SentenceTransformerEmbeddings
-from pgvector.utils import Vector
 
 from src.db_utils import get_db_connection
 from src.file_processor import EMBEDDING_DIM, EMBEDDING_MODEL
@@ -193,7 +193,12 @@ def _store_statute(
                 INSERT INTO statute_article_embedding (article_id, model_name, dim, embedding)
                 VALUES (%s, %s, %s, %s)
                 """,
-                (article_id, EMBEDDING_MODEL, EMBEDDING_DIM, Vector(embedding)),
+                (
+                    article_id,
+                    EMBEDDING_MODEL,
+                    EMBEDDING_DIM,
+                    np.asarray(embedding, dtype=np.float32),
+                ),
             )
 
     conn.commit()

--- a/src/file_processor.py
+++ b/src/file_processor.py
@@ -12,8 +12,8 @@ from dataclasses import dataclass
 from typing import List, Optional, Tuple
 
 import fitz  # PyMuPDF
+import numpy as np
 from langchain_text_splitters import RecursiveCharacterTextSplitter
-from pgvector.utils import Vector
 
 try:  # Optional dependency for DOCX parsing
     import docx  # type: ignore
@@ -353,7 +353,7 @@ def store_document(
                         chunk_id,
                         EMBEDDING_MODEL,
                         EMBEDDING_DIM,
-                        Vector(embedding_vector),
+                        np.asarray(embedding_vector, dtype=np.float32),
                     ),
                 )
         except Exception as exc:


### PR DESCRIPTION
## Summary
- replace direct pgvector Vector usage with numpy arrays when persisting embeddings
- update ingestion scripts and file processor to rely on numpy adapters registered by pgvector

## Testing
- python -m compileall batch_learn.py scripts/ingest_statutes_from_ocr.py scripts/ingest_precedents_from_ocr.py src/file_processor.py

------
https://chatgpt.com/codex/tasks/task_e_68f852339c348324bbb91e999f7a2b34