### PR TITLE
Add Streamlit toggle for LLM provider selection

### DIFF
--- a/demo.py
+++ b/demo.py
@@ -1,4 +1,6 @@
 # 파일명: demo.py (프로젝트 최상위 폴더에 생성)
+import os
+
 import streamlit as st
 from dotenv import load_dotenv
 from src.db_utils import get_db_connection, set_rls_user
@@ -33,6 +35,36 @@ selected_firm = st.sidebar.selectbox(
     index=None,
     placeholder="로그인할 펌을 선택하세요"
 )
+
+provider_options = {
+    "기본 설정 (환경변수 기준)": None,
+    "OpenAI": "openai",
+    "로컬 LLM (Ollama)": "ollama",
+}
+
+env_default_provider = os.getenv("LLM_PROVIDER", "").strip().lower() or None
+if "llm_provider" not in st.session_state:
+    st.session_state.llm_provider = env_default_provider
+
+provider_labels = list(provider_options.keys())
+
+try:
+    default_index = provider_labels.index(
+        next(
+            label
+            for label, value in provider_options.items()
+            if value == st.session_state.llm_provider
+        )
+    )
+except StopIteration:
+    default_index = 0
+
+selected_provider_label = st.sidebar.selectbox(
+    "사용할 LLM 제공자:",
+    provider_labels,
+    index=default_index,
+)
+st.session_state.llm_provider = provider_options[selected_provider_label]
 
 if selected_firm:
     firm_info = firm_list[selected_firm]
@@ -108,7 +140,11 @@ if query:
                 st.warning("관련된 참고 자료를 찾지 못했습니다. LLM이 부정확하게 답변할 수 있습니다.")
             
             # LLM 답변 생성
-            answer, context_str = get_rag_answer(query, context_chunks)
+            answer, context_str = get_rag_answer(
+                query,
+                context_chunks,
+                provider=st.session_state.llm_provider,
+            )
             
             st.subheader("AI 답변")
             st.markdown(answer)

--- a/src/agents.py
+++ b/src/agents.py
@@ -35,11 +35,33 @@ def _normalise_provider(raw: str) -> str:
     return provider
 
 
-def build_chat_model() -> BaseChatModel:
-    """Return a chat model instance based on runtime configuration."""
+def build_chat_model(
+    provider_override: str | None = None,
+    temperature_override: float | None = None,
+) -> BaseChatModel:
+    """Return a chat model instance based on runtime configuration.
 
-    provider = _normalise_provider(os.getenv("LLM_PROVIDER", ""))
-    temperature = float(os.getenv("LLM_TEMPERATURE", "0.2"))
+    Parameters
+    ----------
+    provider_override:
+        Optional manual provider selection (e.g. ``"openai"`` or ``"ollama"``). When
+        omitted the ``LLM_PROVIDER`` environment variable and API key presence are
+        used to determine the backend.
+    temperature_override:
+        Optional manual temperature value. When omitted ``LLM_TEMPERATURE`` is used.
+    """
+
+    raw_provider = (
+        provider_override
+        if provider_override is not None
+        else os.getenv("LLM_PROVIDER", "")
+    )
+    provider = _normalise_provider(raw_provider)
+    temperature = (
+        float(temperature_override)
+        if temperature_override is not None
+        else float(os.getenv("LLM_TEMPERATURE", "0.2"))
+    )
 
     if provider in {"nvidia", "nvidia-ai"} or (
         not provider and os.getenv("NVIDIA_API_KEY")

--- a/src/llm_client.py
+++ b/src/llm_client.py
@@ -22,15 +22,25 @@ RAG_PROMPT_TEMPLATE = """
 """
 
 
-def get_rag_answer(query, context_chunks):
-    """검색된 RAG 청크와 쿼리를 바탕으로 LLM 답변을 생성합니다."""
+def get_rag_answer(query, context_chunks, provider: str | None = None):
+    """검색된 RAG 청크와 쿼리를 바탕으로 LLM 답변을 생성합니다.
+
+    Parameters
+    ----------
+    query:
+        사용자의 질문.
+    context_chunks:
+        RAG 검색으로 수집한 문맥 청크 목록.
+    provider:
+        선택적으로 사용할 LLM 제공자. ``None``이면 환경변수 설정을 따릅니다.
+    """
 
     context_str = "\n\n---\n\n".join(
         f"출처: {chunk['source']}\n내용: {chunk['text']}" for chunk in context_chunks
     )
 
     prompt = ChatPromptTemplate.from_template(RAG_PROMPT_TEMPLATE)
-    chain = prompt | build_chat_model() | StrOutputParser()
+    chain = prompt | build_chat_model(provider_override=provider) | StrOutputParser()
 
     response = chain.invoke({
         "context": context_str,


### PR DESCRIPTION
## Summary
- allow overriding the LLM provider when constructing chat models so the demo can choose at runtime
- expose an optional provider parameter in the RAG helper to pass through the selection
- add a Streamlit sidebar selector to switch between the default, OpenAI, or local Ollama models without editing environment variables

## Testing
- python -m compileall demo.py src

------
https://chatgpt.com/codex/tasks/task_e_68f8737f28048324b8d6fadfd5108db7